### PR TITLE
New discord commands

### DIFF
--- a/wlct/cogs/clot.py
+++ b/wlct/cogs/clot.py
@@ -11,38 +11,62 @@ class Clot(commands.Cog, name="clot"):
 
     @commands.command(brief="Admin commands to manage and debug CLOT",
                       usage='''
-                          bb!admin logs
-                          bb!admin mtc -r <player_token>
-                          bb!admin rtl -r <discord_id>
-                          ''')
+                          bb!admin logs - shows logs
+                          bb!admin mtc -p - Shows current players on the MTC
+                          bb!admin mtc -r <player_token> - removes player from MTC using wz token
+                          bb!admin rtl -p - Shows current players on the RTL
+                          bb!admin rtl -r <discord_id> - removes player from RTL using Discord ID
+                          ''',
+                      category="clot")
     async def admin(self, ctx, cmd="", option="", token=""):
         if  has_admin_access(ctx.message.author.id):
             if cmd == "logs":
                 pass
             elif cmd == "mtc":
                 mtc = MonthlyTemplateRotation.objects.filter(id=22)[0]
-                if option == "-r":
+                if option == "-p":
+                    tplayers = TournamentPlayer.objects.filter(tournament=mtc)
+                    if tplayers:
+                        player_data = "Current Players on the MTC:\n"
+                        for tplayer in tplayers:
+                            if tplayer.team.active:
+                                player_data += "{} | Id: {}\n".format(tplayer.player.name,
+                                                                              tplayer.player.id)
+                        await ctx.send(player_data)
+                    else:
+                        await ctx.send("Currently there are no players on the MTC")
+                elif option == "-r":
                     if token:
                         try:
                             mtc.decline_tournament(token)
                             await ctx.send("Successfully removed player from MTC with id: {}".format(token))
                         except:
-                            await ctx.send("Unable to remove player with id: {}".format(token))
+                            await ctx.send("Unable to remove player from MTC with id: {}".format(token))
                         pass
                 else:
-                    await ctx.send("Please enter a valid option (-r)")
+                    await ctx.send("Please enter a valid option (-p or -r)")
             elif cmd == "rtl":
                 rtl = RealTimeLadder.objects.filter(id=109)[0]
-                if option == "-r":
+                if option == "-p":
+                    tplayers = TournamentPlayer.objects.filter(tournament=rtl)
+                    if tplayers:
+                        player_data = "Current Players on the RTL:\n"
+                        for tplayer in tplayers:
+                            if tplayer.team.active:
+                                player_data += "{} | Discord Id: {}\n".format(tplayer.player.name, tplayer.player.discord_member.memberid)
+                        await ctx.send(player_data)
+                    else:
+                        await ctx.send("Currently there are no players on the RTL")
+                elif option == "-r":
                     if token:
                         try:
                             rtl.leave_ladder(token)
                             await ctx.send("Successfully removed player from RTL with id: {}".format(token))
                         except:
-                            await ctx.send("Unable to remove player with id: {}".format(token))
+                            await ctx.send("Unable to remove player from RTL with id: {}".format(token))
                         pass
                 else:
-                    await ctx.send("Please enter a valid option (-r)")
+                    await ctx.send("Please enter a valid option (-p or -r)")
             else:
                 await ctx.send("Please enter a valid command. Use ``bb!help admin`` to see commands.")
         else:
@@ -279,7 +303,8 @@ class Clot(commands.Cog, name="clot"):
     @commands.command(brief="Displays division data from the CLOT",
                       usage='''
                           bb!divisions : Displays CL Divisions
-                          ''')
+                          ''',
+                      category="clot")
     async def divisions(self, ctx):
         await ctx.send("Gathering tournament data....")
         division_data = "Clan League Divisions\n"
@@ -298,7 +323,8 @@ class Clot(commands.Cog, name="clot"):
                           bb!tournaments -o : Displays Open Tournaments
                           bb!tournaments -p : Displays Tournaments In Progress
                           bb!tournaments -cl : Displays Clan League Tournaments
-                          ''')
+                          ''',
+                      category="clot")
     async def tournaments(self, ctx, arg):
         await ctx.send("Gathering tournament data....")
         tournament_data = ""

--- a/wlct/cogs/clot.py
+++ b/wlct/cogs/clot.py
@@ -1,6 +1,7 @@
 import discord
 from wlct.models import Clan, Player, DiscordUser, DiscordChannelTournamentLink
 from wlct.tournaments import Tournament, TournamentTeam, TournamentPlayer, MonthlyTemplateRotation, get_games_finished_for_team_since, find_tournaments_by_division_id, find_tournament_by_id, get_team_data_no_clan, RealTimeLadder, get_real_time_ladder, get_team_data, ClanLeague, ClanLeagueTournament, ClanLeagueDivision
+from wlct.logging import log_exception
 from discord.ext import commands
 from django.conf import settings
 from wlct.cogs.common import has_admin_access, is_admin
@@ -19,60 +20,64 @@ class Clot(commands.Cog, name="clot"):
                           ''',
                       category="clot")
     async def admin(self, ctx, cmd="", option="", token=""):
-        if  has_admin_access(ctx.message.author.id):
-            if cmd == "logs":
-                pass
-            elif cmd == "mtc":
-                mtc = MonthlyTemplateRotation.objects.filter(id=22)[0]
-                if option == "-p":
-                    tplayers = TournamentPlayer.objects.filter(tournament=mtc)
-                    if tplayers:
-                        player_data = "Current Players on the MTC:\n"
-                        for tplayer in tplayers:
-                            if tplayer.team.active:
-                                player_data += "{} | Id: {}\n".format(tplayer.player.name,
-                                                                              tplayer.player.token)
-                        await ctx.send(player_data)
+        try:
+            if  has_admin_access(ctx.message.author.id):
+                if cmd == "logs":
+                    pass
+                elif cmd == "mtc":
+                    mtc = MonthlyTemplateRotation.objects.filter(id=22)[0]
+                    if option == "-p":
+                        tplayers = TournamentPlayer.objects.filter(tournament=mtc)
+                        if tplayers:
+                            player_data = "Current Players on the MTC:\n"
+                            for tplayer in tplayers:
+                                if tplayer.team.active:
+                                    player_data += "{} | Id: {}\n".format(tplayer.player.name,
+                                                                                  tplayer.player.token)
+                            await ctx.send(player_data)
+                        else:
+                            await ctx.send("Currently there are no players on the MTC")
+                    elif option == "-r":
+                        if token:
+                            try:
+                                mtc.decline_tournament(token)
+                                await ctx.send("Successfully removed player from MTC with id: {}".format(token))
+                            except:
+                                await ctx.send("Unable to remove player from MTC with id: {}".format(token))
+                        else:
+                            ctx.send("Please enter a valid token. Use ``bb!admin mtc -p`` to see current players.")
                     else:
-                        await ctx.send("Currently there are no players on the MTC")
-                elif option == "-r":
-                    if token:
-                        try:
-                            mtc.decline_tournament(token)
-                            await ctx.send("Successfully removed player from MTC with id: {}".format(token))
-                        except:
-                            await ctx.send("Unable to remove player from MTC with id: {}".format(token))
+                        await ctx.send("Please enter a valid option (-p or -r)")
+                elif cmd == "rtl":
+                    rtl = RealTimeLadder.objects.filter(id=109)[0]
+                    if option == "-p":
+                        tplayers = TournamentPlayer.objects.filter(tournament=rtl)
+                        if tplayers:
+                            player_data = "Current Players on the RTL:\n"
+                            for tplayer in tplayers:
+                                if tplayer.team.active:
+                                    player_data += "{} | Discord Id: {}\n".format(tplayer.player.name, tplayer.player.discord_member.memberid)
+                            await ctx.send(player_data)
+                        else:
+                            await ctx.send("Currently there are no players on the RTL")
+                    elif option == "-r":
+                        if token:
+                            try:
+                                rtl.leave_ladder(token)
+                                await ctx.send("Successfully removed player from RTL with id: {}".format(token))
+                            except:
+                                await ctx.send("Unable to remove player from RTL with id: {}".format(token))
+                        else:
+                            ctx.send("Please enter a valid id. Use ``bb!admin rtl -p`` to see current players.")
                     else:
-                        ctx.send("Please enter a valid token. Use ``bb!admin mtc -p`` to see current players.")
+                        await ctx.send("Please enter a valid option (-p or -r)")
                 else:
-                    await ctx.send("Please enter a valid option (-p or -r)")
-            elif cmd == "rtl":
-                rtl = RealTimeLadder.objects.filter(id=109)[0]
-                if option == "-p":
-                    tplayers = TournamentPlayer.objects.filter(tournament=rtl)
-                    if tplayers:
-                        player_data = "Current Players on the RTL:\n"
-                        for tplayer in tplayers:
-                            if tplayer.team.active:
-                                player_data += "{} | Discord Id: {}\n".format(tplayer.player.name, tplayer.player.discord_member.memberid)
-                        await ctx.send(player_data)
-                    else:
-                        await ctx.send("Currently there are no players on the RTL")
-                elif option == "-r":
-                    if token:
-                        try:
-                            rtl.leave_ladder(token)
-                            await ctx.send("Successfully removed player from RTL with id: {}".format(token))
-                        except:
-                            await ctx.send("Unable to remove player from RTL with id: {}".format(token))
-                    else:
-                        ctx.send("Please enter a valid id. Use ``bb!admin rtl -p`` to see current players.")
-                else:
-                    await ctx.send("Please enter a valid option (-p or -r)")
+                    await ctx.send("Please enter a valid command. Use ``bb!help admin`` to see commands.")
             else:
-                await ctx.send("Please enter a valid command. Use ``bb!help admin`` to see commands.")
-        else:
-            await ctx.send("Only clot-admin's can use this command.")
+                await ctx.send("Only clot-admin's can use this command.")
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(
         brief="Links a channel on your server to CL division tournaments on the CLOT. You must be the tournament creator to succesfully link the tournament.",
@@ -82,226 +87,238 @@ class Clot(commands.Cog, name="clot"):
             ''',
         category="clot")
     async def linkd(self, ctx, arg="invalid_cmd", arg2="invalid_id"):
-        discord_user = DiscordUser.objects.filter(memberid=ctx.message.author.id)
-        if not discord_user:
-            discord_user = DiscordUser(memberid=ctx.message.author.id)
-            discord_user.save()
-        else:
-            discord_user = discord_user[0]
-
-        if arg == "invalid_cmd":
-            # list the current links for this channel
-            links = "__**Tournaments Linked to this Channel**__\n"
-            discord_channel_link = DiscordChannelTournamentLink.objects.filter(channelid=ctx.message.channel.id)
-            if discord_channel_link.count() == 0:
-                links += "There are currently no links."
+        try:
+            discord_user = DiscordUser.objects.filter(memberid=ctx.message.author.id)
+            if not discord_user:
+                discord_user = DiscordUser(memberid=ctx.message.author.id)
+                discord_user.save()
             else:
-                for link in discord_channel_link:
-                    links += link.tournament.name + "\n"
-            await ctx.send(links)
-            return
-        elif arg != "-a" and arg != "-r":
-            await ctx.send("Please enter a valid option for the command (-a or -r).")
-            return
+                discord_user = discord_user[0]
 
-        if arg2 == "invalid_id" or not arg2.isnumeric():
-            await ctx.send("Please enter a valid division id to link to this channel.")
-            return
-
-        # we must find the tournament id, and the player associated with the discord user must be the creator
-        # validate that here
-        if ctx.message.author.guild_permissions.administrator or is_admin(ctx.message.author.id):
-            # user is a server admin, process to create the channel -> tournament link
-            tournaments = find_tournaments_by_division_id(int(arg2))
-            total_successfully_updated = 0
-            if not tournaments:
-                await ctx.send(
-                    "Please enter a valid division id to link to this channel. Use ``bb!divisions`` to see list of divisions.")
+            if arg == "invalid_cmd":
+                # list the current links for this channel
+                links = "__**Tournaments Linked to this Channel**__\n"
+                discord_channel_link = DiscordChannelTournamentLink.objects.filter(channelid=ctx.message.channel.id)
+                if discord_channel_link.count() == 0:
+                    links += "There are currently no links."
+                else:
+                    for link in discord_channel_link:
+                        links += link.tournament.name + "\n"
+                await ctx.send(links)
                 return
-            for tournament in tournaments:
-                # if a private tournament, the person sending this command must be linked and be the creator
-                if tournament.private:
-                    player = Player.objects.filter(discord_member__memberid=ctx.message.author.id)
-                    if player:
-                        player = player[0]
-                        if hasattr(tournament, 'parent_tournament'):
-                            if tournament.parent_tournament:
-                                print("Tournament Parent ID {}".format(tournament.parent_tournament.id))
-                            if player.id != tournament.created_by.id and (
-                                    tournament.parent_tournament and tournament.parent_tournament.id != 51):  # hard code this for clan league
-                                await ctx.send(
-                                    "The creator of the tournament is the only one who can link private tournaments: {}".format(
-                                        tournament.name))
-                                continue
+            elif arg != "-a" and arg != "-r":
+                await ctx.send("Please enter a valid option for the command (-a or -r).")
+                return
+
+            if arg2 == "invalid_id" or not arg2.isnumeric():
+                await ctx.send("Please enter a valid division id to link to this channel.")
+                return
+
+            # we must find the tournament id, and the player associated with the discord user must be the creator
+            # validate that here
+            if ctx.message.author.guild_permissions.administrator or is_admin(ctx.message.author.id):
+                # user is a server admin, process to create the channel -> tournament link
+                tournaments = find_tournaments_by_division_id(int(arg2))
+                total_successfully_updated = 0
+                if not tournaments:
+                    await ctx.send(
+                        "Please enter a valid division id to link to this channel. Use ``bb!divisions`` to see list of divisions.")
+                    return
+                for tournament in tournaments:
+                    # if a private tournament, the person sending this command must be linked and be the creator
+                    if tournament.private:
+                        player = Player.objects.filter(discord_member__memberid=ctx.message.author.id)
+                        if player:
+                            player = player[0]
+                            if hasattr(tournament, 'parent_tournament'):
+                                if tournament.parent_tournament:
+                                    print("Tournament Parent ID {}".format(tournament.parent_tournament.id))
+                                if player.id != tournament.created_by.id and (
+                                        tournament.parent_tournament and tournament.parent_tournament.id != 51):  # hard code this for clan league
+                                    await ctx.send(
+                                        "The creator of the tournament is the only one who can link private tournaments: {}".format(
+                                            tournament.name))
+                                    continue
+                            else:
+                                # no parent tournament, must be creator
+                                if player.id != tournament.created_by.id:
+                                    await ctx.send(
+                                        "The creator of the tournament is the only one who can link private tournaments: {}".format(
+                                            tournament.name))
+                                    continue
                         else:
-                            # no parent tournament, must be creator
-                            if player.id != tournament.created_by.id:
-                                await ctx.send(
-                                    "The creator of the tournament is the only one who can link private tournaments: {}".format(
-                                        tournament.name))
-                                continue
-                    else:
-                        await ctx.send(
-                            "Your discord account is not linked to the CLOT. Please see http://wztourney.herokuapp.com/me/ for instructions.")
-                        return
-                if arg == "-a":
-                    # there can be a many:1 relationship from tournaments to channel, so it's completely ok if there's
-                    # already a tournament hooked up to this channel. We don't even check, just add this tournament
-                    # as a link to this channel
-                    discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament,
-                                                                                       channelid=ctx.message.channel.id)
-                    if discord_channel_link:
-                        await ctx.send("You've already linked this channel to tournament: {}".format(tournament.name))
-                        continue
-                    discord_channel_link = DiscordChannelTournamentLink(tournament=tournament,
-                                                                        discord_user=discord_user,
-                                                                        channelid=ctx.message.channel.id)
-                    discord_channel_link.save()
-                    total_successfully_updated += 1
-                elif arg == "-r":
-                    discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament,
-                                                                                       channelid=ctx.message.channel.id)
-                    if discord_channel_link:
-                        discord_channel_link[0].delete()
+                            await ctx.send(
+                                "Your discord account is not linked to the CLOT. Please see http://wztourney.herokuapp.com/me/ for instructions.")
+                            return
+                    if arg == "-a":
+                        # there can be a many:1 relationship from tournaments to channel, so it's completely ok if there's
+                        # already a tournament hooked up to this channel. We don't even check, just add this tournament
+                        # as a link to this channel
+                        discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament,
+                                                                                           channelid=ctx.message.channel.id)
+                        if discord_channel_link:
+                            await ctx.send("You've already linked this channel to tournament: {}".format(tournament.name))
+                            continue
+                        discord_channel_link = DiscordChannelTournamentLink(tournament=tournament,
+                                                                            discord_user=discord_user,
+                                                                            channelid=ctx.message.channel.id)
+                        discord_channel_link.save()
                         total_successfully_updated += 1
-                    else:
-                        await ctx.send(
-                            "There is no existing link for tournament {} and this channel.".format(tournament.name))
-        else:
-            await ctx.send("Sorry, you must be a server administrator to use this command.")
-        if total_successfully_updated and arg == "-a":
-            await ctx.send(
-                "You've linked this channel to {} out of {} tournaments. Game logs will now show-up here in real-time.".format(
+                    elif arg == "-r":
+                        discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament,
+                                                                                           channelid=ctx.message.channel.id)
+                        if discord_channel_link:
+                            discord_channel_link[0].delete()
+                            total_successfully_updated += 1
+                        else:
+                            await ctx.send(
+                                "There is no existing link for tournament {} and this channel.".format(tournament.name))
+            else:
+                await ctx.send("Sorry, you must be a server administrator to use this command.")
+            if total_successfully_updated and arg == "-a":
+                await ctx.send(
+                    "You've linked this channel to {} out of {} tournaments. Game logs will now show-up here in real-time.".format(
+                        total_successfully_updated, len(tournaments)))
+            elif total_successfully_updated and arg == "-r":
+                await ctx.send("You've removed the link to this channel for {} out of {} tournaments.".format(
                     total_successfully_updated, len(tournaments)))
-        elif total_successfully_updated and arg == "-r":
-            await ctx.send("You've removed the link to this channel for {} out of {} tournaments.".format(
-                total_successfully_updated, len(tournaments)))
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(
         brief="Links a channel on your server to a tournament on the CLOT. You must be the tournament creator to succesfully link the tournament.",
         usage='''
-            Hint: to link the RTL, use the command: ``bb!linkt -a 109``
+            Hint: you can link the RTL (id: 109) and the MTC (id: 22) game logs
             bb!linkt -a tournament_id - adds a link from this discord channel to stream game logs for tournament_id
             bb!linkt -r tournament_id - removes an existing link from this discord channel to tournament_id
             ''',
         category="clot")
     async def linkt(self, ctx, arg="invalid_cmd", arg2="invalid_id"):
-        discord_user = DiscordUser.objects.filter(memberid=ctx.message.author.id)
-        if not discord_user:
-            discord_user = DiscordUser(memberid=ctx.message.author.id)
-            discord_user.save()
-        else:
-            discord_user = discord_user[0]
-
-        if arg == "invalid_cmd":
-            # list the current links for this channel
-            links = "__**Tournaments Linked to this Channel**__\n"
-            discord_channel_link = DiscordChannelTournamentLink.objects.filter(channelid=ctx.message.channel.id)
-            if discord_channel_link.count() == 0:
-                links += "There are currently no links."
+        try:
+            discord_user = DiscordUser.objects.filter(memberid=ctx.message.author.id)
+            if not discord_user:
+                discord_user = DiscordUser(memberid=ctx.message.author.id)
+                discord_user.save()
             else:
-                for link in discord_channel_link:
-                    links += link.tournament.name + "\n"
-            await ctx.send(links)
-            return
-        elif arg != "-a" and arg != "-r":
-            await ctx.send("Please enter a valid option for the command (-a or -r).")
-            return
+                discord_user = discord_user[0]
 
-        if arg2 == "invalid_id" or not arg2.isnumeric():
-            await ctx.send("Please enter a valid tournament or league id to link to this channel.")
-            return
+            if arg == "invalid_cmd":
+                # list the current links for this channel
+                links = "__**Tournaments Linked to this Channel**__\n"
+                discord_channel_link = DiscordChannelTournamentLink.objects.filter(channelid=ctx.message.channel.id)
+                if discord_channel_link.count() == 0:
+                    links += "There are currently no links."
+                else:
+                    for link in discord_channel_link:
+                        links += link.tournament.name + "\n"
+                await ctx.send(links)
+                return
+            elif arg != "-a" and arg != "-r":
+                await ctx.send("Please enter a valid option for the command (-a or -r).")
+                return
 
-        # we must find the tournament id, and the player associated with the discord user must be the creator
-        # validate that here
-        if ctx.message.author.guild_permissions.administrator or is_admin(ctx.message.author.id):
-            # user is a server admin, process to create the channel -> tournament link
-            tournament = find_tournament_by_id(int(arg2), True)
-            if tournament:
-                # if a private tournament, the person sending this command must be linked and be the creator
-                if tournament.private:
-                    player = Player.objects.filter(discord_member__memberid=ctx.message.author.id)
-                    if player:
-                        player = player[0]
-                        if hasattr(tournament, 'parent_tournament'):
-                            if tournament.parent_tournament:
-                                print("Tournament Parent ID {}".format(tournament.parent_tournament.id))
-                            if player.id != tournament.created_by.id and (tournament.parent_tournament and tournament.parent_tournament.id != 51):  # hard code this for clan league
-                                await ctx.send("The creator of the tournament is the only one who can link private tournaments.")
-                                return
-                        else:
-                            # no parent tournament, must be creator
-                            if player.id != tournament.created_by.id:
-                                await ctx.send(
-                                    "The creator of the tournament is the only one who can link private tournaments.")
-                                return
-                    else:
-                        await ctx.send("Your discord account is not linked to the CLOT. Please see http://wztourney.herokuapp.com/me/ for instructions.")
-                        return
-                if arg == "-a":
-                    # there can be a many:1 relationship from tournaments to channel, so it's completely ok if there's
-                    # already a tournament hooked up to this channel. We don't even check, just add this tournament
-                    # as a link to this channel
-                    discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament, channelid=ctx.message.channel.id)
-                    if discord_channel_link:
-                        await ctx.send("You've already linked this channel to tournament: {}".format(tournament.name))
-                        return
-                    discord_channel_link = DiscordChannelTournamentLink(tournament=tournament, discord_user=discord_user, channelid=ctx.message.channel.id)
-                    discord_channel_link.save()
-                    await ctx.send("You've linked this channel to tournament: {}. Game logs will now show-up here in real-time.".format(tournament.name))
-                elif arg == "-r":
-                    discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament, channelid=ctx.message.channel.id)
-                    if discord_channel_link:
-                        discord_channel_link[0].delete()
-                        await ctx.send("You've removed the link from this channel and tournament: {}".format(tournament.name))
-                    else:
-                        await ctx.send("There is no existing link for tournament {} and this channel.")
-            else:
+            if arg2 == "invalid_id" or not arg2.isnumeric():
                 await ctx.send("Please enter a valid tournament or league id to link to this channel.")
-        else:
-            await ctx.send("Sorry, you must be a server administrator to use this command.")
+                return
+
+            # we must find the tournament id, and the player associated with the discord user must be the creator
+            # validate that here
+            if ctx.message.author.guild_permissions.administrator or is_admin(ctx.message.author.id):
+                # user is a server admin, process to create the channel -> tournament link
+                tournament = find_tournament_by_id(int(arg2), True)
+                if tournament:
+                    # if a private tournament, the person sending this command must be linked and be the creator
+                    if tournament.private:
+                        player = Player.objects.filter(discord_member__memberid=ctx.message.author.id)
+                        if player:
+                            player = player[0]
+                            if hasattr(tournament, 'parent_tournament'):
+                                if tournament.parent_tournament:
+                                    print("Tournament Parent ID {}".format(tournament.parent_tournament.id))
+                                if player.id != tournament.created_by.id and (tournament.parent_tournament and tournament.parent_tournament.id != 51):  # hard code this for clan league
+                                    await ctx.send("The creator of the tournament is the only one who can link private tournaments.")
+                                    return
+                            else:
+                                # no parent tournament, must be creator
+                                if player.id != tournament.created_by.id:
+                                    await ctx.send(
+                                        "The creator of the tournament is the only one who can link private tournaments.")
+                                    return
+                        else:
+                            await ctx.send("Your discord account is not linked to the CLOT. Please see http://wztourney.herokuapp.com/me/ for instructions.")
+                            return
+                    if arg == "-a":
+                        # there can be a many:1 relationship from tournaments to channel, so it's completely ok if there's
+                        # already a tournament hooked up to this channel. We don't even check, just add this tournament
+                        # as a link to this channel
+                        discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament, channelid=ctx.message.channel.id)
+                        if discord_channel_link:
+                            await ctx.send("You've already linked this channel to tournament: {}".format(tournament.name))
+                            return
+                        discord_channel_link = DiscordChannelTournamentLink(tournament=tournament, discord_user=discord_user, channelid=ctx.message.channel.id)
+                        discord_channel_link.save()
+                        await ctx.send("You've linked this channel to tournament: {}. Game logs will now show-up here in real-time.".format(tournament.name))
+                    elif arg == "-r":
+                        discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament, channelid=ctx.message.channel.id)
+                        if discord_channel_link:
+                            discord_channel_link[0].delete()
+                            await ctx.send("You've removed the link from this channel and tournament: {}".format(tournament.name))
+                        else:
+                            await ctx.send("There is no existing link for tournament {} and this channel.")
+                else:
+                    await ctx.send("Please enter a valid tournament or league id to link to this channel.")
+            else:
+                await ctx.send("Sorry, you must be a server administrator to use this command.")
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(
         brief="Links your discord account with your CLOT/Warzone account for use with creating games and bot ladders.",
         usage="bot_token_from_clot_site",
         category="clot")
     async def linkme(self, ctx, arg):
-        if isinstance(ctx.message.channel, discord.DMChannel):
-            print("Token for linking: {} for user: {}".format(arg, ctx.message.author.id))
-            # check to see if this player is already linked
-            player = Player.objects.filter(bot_token=arg)
-            if player:
-                player = player[0]
-                # make sure the discord id is not already here
-                current_discord = Player.objects.filter(discord_member__memberid=ctx.message.author.id)
-                if current_discord:
-                    current_discord = current_discord[0]
-                    cd_name = self.bot.get_user(current_discord.discord_member.memberid)
-                    new_name = ctx.message.author.name
+        try:
+            if isinstance(ctx.message.channel, discord.DMChannel):
+                print("Token for linking: {} for user: {}".format(arg, ctx.message.author.id))
+                # check to see if this player is already linked
+                player = Player.objects.filter(bot_token=arg)
+                if player:
+                    player = player[0]
+                    # make sure the discord id is not already here
+                    current_discord = Player.objects.filter(discord_member__memberid=ctx.message.author.id)
+                    if current_discord:
+                        current_discord = current_discord[0]
+                        cd_name = self.bot.get_user(current_discord.discord_member.memberid)
+                        new_name = ctx.message.author.name
 
-                    # do the unlinking
-                    player.discord_member = None
-                    player.save()
-                    await ctx.send("Your discord ID is already associated with another account, unlinking {} and linking {}.".format(cd_name, new_name))
+                        # do the unlinking
+                        player.discord_member = None
+                        player.save()
+                        await ctx.send("Your discord ID is already associated with another account, unlinking {} and linking {}.".format(cd_name, new_name))
 
-                if player.discord_member is not None and player.discord_member.memberid == ctx.message.author.id:
-                    await ctx.send("You're account is already linked on the CLOT.")
-                elif player.discord_member is None:
-                    print("Saving discord id: {} for user".format(ctx.message.author.id))
-                    discord_obj = DiscordUser.objects.filter(memberid=ctx.message.author.id)
-                    if not discord_obj:
-                        discord_obj = DiscordUser(memberid=ctx.message.author.id)
-                        discord_obj.save()
-                    else:
-                        discord_obj = discord_obj[0]
-                    player.discord_member = discord_obj
-                    player.save()
-                    await ctx.send("You've successfully linked your discord account to the CLOT.")
+                    if player.discord_member is not None and player.discord_member.memberid == ctx.message.author.id:
+                        await ctx.send("You're account is already linked on the CLOT.")
+                    elif player.discord_member is None:
+                        print("Saving discord id: {} for user".format(ctx.message.author.id))
+                        discord_obj = DiscordUser.objects.filter(memberid=ctx.message.author.id)
+                        if not discord_obj:
+                            discord_obj = DiscordUser(memberid=ctx.message.author.id)
+                            discord_obj.save()
+                        else:
+                            discord_obj = discord_obj[0]
+                        player.discord_member = discord_obj
+                        player.save()
+                        await ctx.send("You've successfully linked your discord account to the CLOT.")
+                else:
+                    await ctx.send(
+                        "Bot token is invalid. Please visit http://wztourney.herokuapp.com/me to retrieve your token.")
             else:
-                await ctx.send(
-                    "Bot token is invalid. Please visit http://wztourney.herokuapp.com/me to retrieve your token.")
-        else:
-            await ctx.send("You cannot use the !linkme command unless you are privately messaging the bot.")
+                await ctx.send("You cannot use the !linkme command unless you are privately messaging the bot.")
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(brief="Displays division data from the CLOT",
                       usage='''
@@ -309,16 +326,20 @@ class Clot(commands.Cog, name="clot"):
                           ''',
                       category="clot")
     async def divisions(self, ctx):
-        await ctx.send("Gathering tournament data....")
-        division_data = "Clan League Divisions\n"
+        try:
+            await ctx.send("Gathering tournament data....")
+            division_data = "Clan League Divisions\n"
 
-        cl = ClanLeague.objects.filter(id=12)[0]
-        divisions = ClanLeagueDivision.objects.filter(league=cl).order_by('+title')
+            cl = ClanLeague.objects.filter(id=12)[0]
+            divisions = ClanLeagueDivision.objects.filter(league=cl).order_by('+title')
 
-        for division in divisions:
-            division_data += "{} | Id: {}\n".format(division.title, division.id)
+            for division in divisions:
+                division_data += "{} | Id: {}\n".format(division.title, division.id)
 
-        await ctx.send(division_data)
+            await ctx.send(division_data)
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(brief="Displays tournament data from the CLOT",
                       usage='''
@@ -329,66 +350,74 @@ class Clot(commands.Cog, name="clot"):
                           ''',
                           category="clot")
     async def tournaments(self, ctx, arg):
-        await ctx.send("Gathering tournament data....")
-        tournament_data = ""
-        tournaments = Tournament.objects.all()
-        if arg == "-f":
-            tournament_data += "Finished Tournaments\n"
-        elif arg == "-o":
-            tournament_data += "Open Tournaments\n"
-        elif arg == "-p":
-            tournament_data += "Tournaments In Progress\n"
-        elif arg == "-cl":
-            tournament_data += "Clan League Tournaments\n"
-        else:
-            await ctx.send("You must specify an option. Use ``bb!help tournaments`` to see commands.")
+        try:
+            await ctx.send("Gathering tournament data....")
+            tournament_data = ""
+            tournaments = Tournament.objects.all()
+            if arg == "-f":
+                tournament_data += "Finished Tournaments\n"
+            elif arg == "-o":
+                tournament_data += "Open Tournaments\n"
+            elif arg == "-p":
+                tournament_data += "Tournaments In Progress\n"
+            elif arg == "-cl":
+                tournament_data += "Clan League Tournaments\n"
+            else:
+                await ctx.send("You must specify an option. Use ``bb!help tournaments`` to see commands.")
 
-        for tournament in tournaments:
-            child_tournament = find_tournament_by_id(tournament.id, True)
-            if child_tournament:
-                link_text = "http://wztourney.herokuapp.com/"
-                if child_tournament.is_league:
-                    link_text += "leagues/{}".format(child_tournament.id)
-                else:
-                    link_text += "tournaments/{}".format(child_tournament.id)
-                if arg == "-f":  # only finished tournaments
-                    if child_tournament.is_finished:
-                        tournament_data += "{} | <{}> | Winner: {}\n".format(child_tournament.name, link_text,
-                                                                     get_team_data(child_tournament.winning_team))
-                elif arg == "-o":  # only open tournaments
-                    if not child_tournament.has_started and not child_tournament.private:
-                        tournament_data += "{} | <{}> | {} spots left\n".format(child_tournament.name, link_text,
-                                                                           child_tournament.spots_left)
-                elif arg == "-p":  # only in progress
-                    if child_tournament.has_started and not child_tournament.private:
-                        tournament_data += "{} | <{}>\n".format(child_tournament.name, link_text)
-                elif arg == "-cl":  # only in progress
-                    if child_tournament.id == 51 and child_tournament.has_started:
-                        cl_tourneys = ClanLeagueTournament.objects.filter(parent_tournament=child_tournament).order_by('id')
-                        for cl_tourney in cl_tourneys:
-                            tournament_data += "{} | Id: {}\n".format(cl_tourney.name, cl_tourney.id)
-        await ctx.send(tournament_data)
+            for tournament in tournaments:
+                child_tournament = find_tournament_by_id(tournament.id, True)
+                if child_tournament:
+                    link_text = "http://wztourney.herokuapp.com/"
+                    if child_tournament.is_league:
+                        link_text += "leagues/{}".format(child_tournament.id)
+                    else:
+                        link_text += "tournaments/{}".format(child_tournament.id)
+                    if arg == "-f":  # only finished tournaments
+                        if child_tournament.is_finished:
+                            tournament_data += "{} | <{}> | Winner: {}\n".format(child_tournament.name, link_text,
+                                                                         get_team_data(child_tournament.winning_team))
+                    elif arg == "-o":  # only open tournaments
+                        if not child_tournament.has_started and not child_tournament.private:
+                            tournament_data += "{} | <{}> | {} spots left\n".format(child_tournament.name, link_text,
+                                                                               child_tournament.spots_left)
+                    elif arg == "-p":  # only in progress
+                        if child_tournament.has_started and not child_tournament.private:
+                            tournament_data += "{} | <{}>\n".format(child_tournament.name, link_text)
+                    elif arg == "-cl":  # only in progress
+                        if child_tournament.id == 51 and child_tournament.has_started:
+                            cl_tourneys = ClanLeagueTournament.objects.filter(parent_tournament=child_tournament).order_by('id')
+                            for cl_tourney in cl_tourneys:
+                                tournament_data += "{} | Id: {}\n".format(cl_tourney.name, cl_tourney.id)
+            await ctx.send(tournament_data)
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(brief="Displays the MTC top ten on the CLOT")
     async def mtc(self, ctx):
-        await ctx.send("Gathering Monthly Template Rotation data....")
-        tournament_data = ""
-        tournament = MonthlyTemplateRotation.objects.filter(id=22)
-        if tournament:
-            tournament = tournament[0]
-            tournamentteams = TournamentTeam.objects.filter(tournament=tournament.id, active=True).order_by('-rating',
-                                                                                                            '-wins')
-            tournament_data += "MTC Top 10\n"
-            teams_found = 0
-            for team in tournamentteams:
-                if teams_found <= 10:
-                    games_finished = get_games_finished_for_team_since(team.id, tournament, 90)
-                    if games_finished >= 10:
-                        tournament_data += "{}) {} - {}\n".format(teams_found + 1, get_team_data_no_clan(team), team.rating)
-                        teams_found += 1
+        try:
+            await ctx.send("Gathering Monthly Template Rotation data....")
+            tournament_data = ""
+            tournament = MonthlyTemplateRotation.objects.filter(id=22)
+            if tournament:
+                tournament = tournament[0]
+                tournamentteams = TournamentTeam.objects.filter(tournament=tournament.id, active=True).order_by('-rating',
+                                                                                                                '-wins')
+                tournament_data += "MTC Top 10\n"
+                teams_found = 0
+                for team in tournamentteams:
+                    if teams_found <= 10:
+                        games_finished = get_games_finished_for_team_since(team.id, tournament, 90)
+                        if games_finished >= 10:
+                            tournament_data += "{}) {} - {}\n".format(teams_found + 1, get_team_data_no_clan(team), team.rating)
+                            teams_found += 1
 
-        print("MTC: {}\nLength: {}".format(tournament_data, len(tournament_data)))
-        await ctx.send(tournament_data)
+            print("MTC: {}\nLength: {}".format(tournament_data, len(tournament_data)))
+            await ctx.send(tournament_data)
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(brief="Displays all registered clan members on the CLOT",
                       usage='''
@@ -397,55 +426,67 @@ class Clot(commands.Cog, name="clot"):
                           bb!clan clanid -d - List of players in the clan who have linked their discord accounts
                           ''')
     async def clan(self, ctx, clanid, discord_arg=""):
-        await ctx.send("Gathering player data for clan {}....".format(clanid))
-        clan_obj = Clan.objects.filter(pk=int(clanid))
-        emb = discord.Embed(color=self.bot.embed_color)
-        if clan_obj:
-            emb.title = "{}".format(clan_obj[0].name)
-            emb.set_thumbnail(url=clan_obj[0].image_path)
-            player_data = ""
-            field_name = ""
-            if discord_arg != "-d":
-                field_name = "Registered on CLOT"
-                players = Player.objects.filter(clan=clan_obj[0].id).order_by('name')
+        try:
+            await ctx.send("Gathering player data for clan {}....".format(clanid))
+            clan_obj = Clan.objects.filter(pk=int(clanid))
+            emb = discord.Embed(color=self.bot.embed_color)
+            if clan_obj:
+                emb.title = "{}".format(clan_obj[0].name)
+                emb.set_thumbnail(url=clan_obj[0].image_path)
+                player_data = ""
+                field_name = ""
+                if discord_arg != "-d":
+                    field_name = "Registered on CLOT"
+                    players = Player.objects.filter(clan=clan_obj[0].id).order_by('name')
+                else:
+                    field_name = "Discord Linked on CLOT"
+                    players = Player.objects.filter(clan=clan_obj[0].id, discord_member__isnull=False).order_by('name')
+                current_player = 0
+                if players:
+                    for player in players:
+                        current_player += 1
+                        player_data += "{} [Profile](https://www.warzone.com/Profile?p={})\n".format(player.name, player.token)
+                        if current_player % 10 == 0:
+                            emb.add_field(name=field_name, value=player_data)
+                            player_data = ""  # reset this for the next embed
+                    emb.add_field(name=field_name, value=player_data)
+                    await ctx.send(embed=emb)
+                else:
+                    await ctx.send("No players are registered on the CLOt for {}".format(clan_obj[0].name))
             else:
-                field_name = "Discord Linked on CLOT"
-                players = Player.objects.filter(clan=clan_obj[0].id, discord_member__isnull=False).order_by('name')
-            current_player = 0
-            if players:
-                for player in players:
-                    current_player += 1
-                    player_data += "{} [Profile](https://www.warzone.com/Profile?p={})\n".format(player.name, player.token)
-                    if current_player % 10 == 0:
-                        emb.add_field(name=field_name, value=player_data)
-                        player_data = ""  # reset this for the next embed
-                emb.add_field(name=field_name, value=player_data)
-                await ctx.send(embed=emb)
-            else:
-                await ctx.send("No players are registered on the CLOt for {}".format(clan_obj[0].name))
-        else:
-            await ctx.send("Clan with id {} not found. Please use bb!clans to show valid clans.".format(clanid))
+                await ctx.send("Clan with id {} not found. Please use bb!clans to show valid clans.".format(clanid))
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(brief="Displays all clans on the CLOT")
     async def clans(self, ctx):
-        clans = Clan.objects.all()
-        await ctx.send("Gathering clans data....")
-        clans_data = "Clans on the CLOT\n\n"
-        for clan in clans:
-            player = Player.objects.filter(clan=clan)
-            if player:
-                clans_data += "{}: {}\n".format(clan.id, clan.name)
-        await ctx.send(clans_data)
+        try:
+            clans = Clan.objects.all()
+            await ctx.send("Gathering clans data....")
+            clans_data = "Clans on the CLOT\n\n"
+            for clan in clans:
+                player = Player.objects.filter(clan=clan)
+                if player:
+                    clans_data += "{}: {}\n".format(clan.id, clan.name)
+            await ctx.send(clans_data)
+        except:
+            log_exception()
+            ctx.send("An error has occurred, unable to process command.")
 
     @commands.command(brief="Display your Warzone Profile Link")
     async def profile(self, ctx):
-        discord_id = ctx.message.author.id
+        try:
+            discord_id = ctx.message.author.id
 
-        player = Player.objects.filter(discord_member__memberid=discord_id)
-        if player:
-            await ctx.send("{} | https://warzone.com/Profile?p={}".format(player.name, player.token))
-        else:
-            await ctx.send("Your discord account is not linked to the CLOT. Please see http://wztourney.herokuapp.com/me/ for instructions.")
+            player = Player.objects.filter(discord_member__memberid=discord_id)
+            if player:
+                await ctx.send("{} | https://warzone.com/Profile?p={}".format(player.name, player.token))
+            else:
+                await ctx.send("Your discord account is not linked to the CLOT. Please see http://wztourney.herokuapp.com/me/ for instructions.")
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
 
 def setup(bot):

--- a/wlct/cogs/clot.py
+++ b/wlct/cogs/clot.py
@@ -12,9 +12,9 @@ class Clot(commands.Cog, name="clot"):
     @commands.command(brief="Admin commands to manage and debug CLOT",
                       usage='''
                           bb!admin logs - shows logs
-                          bb!admin mtc -p - Shows current players on the MTC
+                          bb!admin mtc -p - shows current players on the MTC
                           bb!admin mtc -r <player_token> - removes player from MTC using wz token
-                          bb!admin rtl -p - Shows current players on the RTL
+                          bb!admin rtl -p - shows current players on the RTL
                           bb!admin rtl -r <discord_id> - removes player from RTL using Discord ID
                           ''',
                       category="clot")
@@ -31,7 +31,7 @@ class Clot(commands.Cog, name="clot"):
                         for tplayer in tplayers:
                             if tplayer.team.active:
                                 player_data += "{} | Id: {}\n".format(tplayer.player.name,
-                                                                              tplayer.player.id)
+                                                                              tplayer.player.token)
                         await ctx.send(player_data)
                     else:
                         await ctx.send("Currently there are no players on the MTC")
@@ -42,7 +42,8 @@ class Clot(commands.Cog, name="clot"):
                             await ctx.send("Successfully removed player from MTC with id: {}".format(token))
                         except:
                             await ctx.send("Unable to remove player from MTC with id: {}".format(token))
-                        pass
+                    else:
+                        ctx.send("Please enter a valid token. Use ``bb!admin mtc -p`` to see current players.")
                 else:
                     await ctx.send("Please enter a valid option (-p or -r)")
             elif cmd == "rtl":
@@ -64,7 +65,8 @@ class Clot(commands.Cog, name="clot"):
                             await ctx.send("Successfully removed player from RTL with id: {}".format(token))
                         except:
                             await ctx.send("Unable to remove player from RTL with id: {}".format(token))
-                        pass
+                    else:
+                        ctx.send("Please enter a valid id. Use ``bb!admin rtl -p`` to see current players.")
                 else:
                     await ctx.send("Please enter a valid option (-p or -r)")
             else:
@@ -178,6 +180,7 @@ class Clot(commands.Cog, name="clot"):
     @commands.command(
         brief="Links a channel on your server to a tournament on the CLOT. You must be the tournament creator to succesfully link the tournament.",
         usage='''
+            Hint: to link the RTL, use the command: ``bb!linkt -a 109``
             bb!linkt -a tournament_id - adds a link from this discord channel to stream game logs for tournament_id
             bb!linkt -r tournament_id - removes an existing link from this discord channel to tournament_id
             ''',
@@ -324,7 +327,7 @@ class Clot(commands.Cog, name="clot"):
                           bb!tournaments -p : Displays Tournaments In Progress
                           bb!tournaments -cl : Displays Clan League Tournaments
                           ''',
-                      category="clot")
+                          category="clot")
     async def tournaments(self, ctx, arg):
         await ctx.send("Gathering tournament data....")
         tournament_data = ""

--- a/wlct/cogs/clot.py
+++ b/wlct/cogs/clot.py
@@ -93,6 +93,99 @@ class Clot(commands.Cog, name="clot"):
             await ctx.send("Sorry, you must be a server administrator to use this command.")
 
     @commands.command(
+        brief="Links a channel on your server to a tournament on the CLOT. You must be the tournament creator to use succesfully link the tournament.",
+        usage='''
+                bb!linkd -a division_id - adds a link from this discord channel to stream game logs for tournament_id
+                bb!linkt -r division_id - removes an existing link from this discord channel to tournament_id
+                ''',
+        category="clot")
+    async def linkd(self, ctx, arg="invalid_cmd", arg2="invalid_id"):
+        discord_user = DiscordUser.objects.filter(memberid=ctx.message.author.id)
+        if not discord_user:
+            discord_user = DiscordUser(memberid=ctx.message.author.id)
+            discord_user.save()
+        else:
+            discord_user = discord_user[0]
+
+        if arg == "invalid_cmd":
+            # list the current links for this channel
+            links = "__**Tournaments Linked to this Channel**__\n"
+            discord_channel_link = DiscordChannelTournamentLink.objects.filter(channelid=ctx.message.channel.id)
+            if discord_channel_link.count() == 0:
+                links += "There are currently no links."
+            else:
+                for link in discord_channel_link:
+                    links += link.tournament.name + "\n"
+            await ctx.send(links)
+            return
+        elif arg != "-a" and arg != "-r":
+            await ctx.send("Please enter a valid option for the command (-a or -r).")
+            return
+
+        if arg2 == "invalid_id" or not arg2.isnumeric():
+            await ctx.send("Please enter a valid tournament or league id to link to this channel.")
+            return
+
+        # we must find the tournament id, and the player associated with the discord user must be the creator
+        # validate that here
+        if ctx.message.author.guild_permissions.administrator or is_admin(ctx.message.author.id):
+            # user is a server admin, process to create the channel -> tournament link
+            tournament = find_tournament_by_id(int(arg2), True)
+            if tournament:
+                # if a private tournament, the person sending this command must be linked and be the creator
+                if tournament.private:
+                    player = Player.objects.filter(discord_member__memberid=ctx.message.author.id)
+                    if player:
+                        player = player[0]
+                        if hasattr(tournament, 'parent_tournament'):
+                            if tournament.parent_tournament:
+                                print("Tournament Parent ID {}".format(tournament.parent_tournament.id))
+                            if player.id != tournament.created_by.id and (
+                                    tournament.parent_tournament and tournament.parent_tournament.id != 51):  # hard code this for clan league
+                                await ctx.send(
+                                    "The creator of the tournament is the only one who can link private tournaments.")
+                                return
+                        else:
+                            # no parent tournament, must be creator
+                            if player.id != tournament.created_by.id:
+                                await ctx.send(
+                                    "The creator of the tournament is the only one who can link private tournaments.")
+                                return
+                    else:
+                        await ctx.send(
+                            "Your discord account is not linked to the CLOT. Please see http://wztourney.herokuapp.com/me/ for instructions.")
+                        return
+                if arg == "-a":
+                    # there can be a many:1 relationship from tournaments to channel, so it's completely ok if there's
+                    # already a tournament hooked up to this channel. We don't even check, just add this tournament
+                    # as a link to this channel
+                    discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament,
+                                                                                       channelid=ctx.message.channel.id)
+                    if discord_channel_link:
+                        await ctx.send("You've already linked this channel to tournament: {}".format(tournament.name))
+                        return
+                    discord_channel_link = DiscordChannelTournamentLink(tournament=tournament,
+                                                                        discord_user=discord_user,
+                                                                        channelid=ctx.message.channel.id)
+                    discord_channel_link.save()
+                    await ctx.send(
+                        "You've linked this channel to tournament: {}. Game logs will now show-up here in real-time.".format(
+                            tournament.name))
+                elif arg == "-r":
+                    discord_channel_link = DiscordChannelTournamentLink.objects.filter(tournament=tournament,
+                                                                                       channelid=ctx.message.channel.id)
+                    if discord_channel_link:
+                        discord_channel_link[0].delete()
+                        await ctx.send(
+                            "You've removed the link from this channel and tournament: {}".format(tournament.name))
+                    else:
+                        await ctx.send("There is no existing link for tournament {} and this channel.")
+            else:
+                await ctx.send("Please enter a valid tournament or league id to link to this channel.")
+        else:
+            await ctx.send("Sorry, you must be a server administrator to use this command.")
+
+    @commands.command(
         brief="Links your discord account with your CLOT/Warzone account for use with creating games and bot ladders.",
         usage="bot_token_from_clot_site",
         category="clot")

--- a/wlct/cogs/common.py
+++ b/wlct/cogs/common.py
@@ -12,6 +12,12 @@ import datetime
 from django.core.paginator import Paginator
 
 
+def has_admin_role(roles):
+    for role in roles:
+        if role.name == "clot-admin" or role.name == "admin":
+            return True
+    return False
+
 def is_admin(discord_id):
     if str(discord_id) == "288807658264330242":
         return True

--- a/wlct/cogs/common.py
+++ b/wlct/cogs/common.py
@@ -5,7 +5,7 @@ import requests
 import json
 from bs4 import BeautifulSoup
 from wlct.models import Engine
-from wlct.logging import TournamentGameLog, ProcessGameLog
+from wlct.logging import TournamentGameLog, ProcessGameLog, log_exception
 from wlct.cogs.help import get_help_embed
 from django.utils import timezone
 import datetime
@@ -34,20 +34,24 @@ class Common(commands.Cog, name="general"):
                       status wz
                       ''')
     async def status(self, ctx, server):
-        url = ""
-        if server == "clot" or server == "CLOT":
-            url = 'http://wztourney.herokuapp.com'
-            r = requests.get(url)
-        elif server == "wz" or server == "WZ":
-            url = 'https://www.warzone.com/MultiPlayer/'
-            r = requests.get(url)
-        r.status_code
-        if str(r.status_code) == "200":
-            status = "{} - ONLINE".format(url)
-        else:
-            status = "{} - OFFLINE".format(url)
+        try:
+            url = ""
+            if server == "clot" or server == "CLOT":
+                url = 'http://wztourney.herokuapp.com'
+                r = requests.get(url)
+            elif server == "wz" or server == "WZ":
+                url = 'https://www.warzone.com/MultiPlayer/'
+                r = requests.get(url)
+            r.status_code
+            if str(r.status_code) == "200":
+                status = "{} - ONLINE".format(url)
+            else:
+                status = "{} - OFFLINE".format(url)
 
-        await ctx.send("Server Status: {}".format(status))
+            await ctx.send("Server Status: {}".format(status))
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
 
     def get_minutes_seconds(self, timedelta):
@@ -59,38 +63,46 @@ class Common(commands.Cog, name="general"):
 
     @commands.command(brief="Displays data about the engine")
     async def engine(self, ctx):
-        engine = Engine.objects.all()
-        if engine:
-            engine = engine[0]
-            time_since_run = timezone.now() - engine.last_run_time
-            if engine.next_run_time:
-                time_to_run = engine.next_run_time - timezone.now()
+        try:
+            engine = Engine.objects.all()
+            if engine:
+                engine = engine[0]
+                time_since_run = timezone.now() - engine.last_run_time
+                if engine.next_run_time:
+                    time_to_run = engine.next_run_time - timezone.now()
 
-            text = "Last run {} minutes and {} seconds ago\n".format(self.get_minutes_seconds(time_since_run)[0], self.get_minutes_seconds(time_since_run)[1])
-            if engine.next_run_time:
-                text += "Next run in {} minutes, {} seconds".format(self.get_minutes_seconds(time_to_run)[0], self.get_minutes_seconds(time_to_run)[1])
-            await ctx.send(text)
+                text = "Last run {} minutes and {} seconds ago\n".format(self.get_minutes_seconds(time_since_run)[0], self.get_minutes_seconds(time_since_run)[1])
+                if engine.next_run_time:
+                    text += "Next run in {} minutes, {} seconds".format(self.get_minutes_seconds(time_to_run)[0], self.get_minutes_seconds(time_to_run)[1])
+                await ctx.send(text)
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
 
     @commands.command(brief="[admin] Displays game logs for a tournament",
                       usage="bb!game_logs <gameid> <num_logs> <pages>")
     async def game_logs(self, ctx, game_id=0, num_logs=-1, page=-1):
-        if is_admin(ctx.message.author.id):
-            if game_id != 0 and num_logs != -1 and page != -1:
-                # good
-                print("Game Id: {}, num_logs per page: {}, page: {}".format(game_id, num_logs, page))
-                game_logs = ProcessGameLog.objects.filter(game__gameid=int(game_id)).order_by('id')
-                print("Number game logs: {}".format(game_logs.count()))
-                paginator = Paginator(game_logs, num_logs)
-                page = paginator.get_page(page)
-                for log in page:
-                    await ctx.message.author.send(log.msg[0:1900])
-                    if len(log.msg) > 1900:
-                        await ctx.message.author.send(log.msg[1900:])
+        try:
+            if is_admin(ctx.message.author.id):
+                if game_id != 0 and num_logs != -1 and page != -1:
+                    # good
+                    print("Game Id: {}, num_logs per page: {}, page: {}".format(game_id, num_logs, page))
+                    game_logs = ProcessGameLog.objects.filter(game__gameid=int(game_id)).order_by('id')
+                    print("Number game logs: {}".format(game_logs.count()))
+                    paginator = Paginator(game_logs, num_logs)
+                    page = paginator.get_page(page)
+                    for log in page:
+                        await ctx.message.author.send(log.msg[0:1900])
+                        if len(log.msg) > 1900:
+                            await ctx.message.author.send(log.msg[1900:])
+                else:
+                    await ctx.send("You must pass in all parameters to the command.")
             else:
-                await ctx.send("You must pass in all parameters to the command.")
-        else:
-            await ctx.send("You must be an admin to use this command")
+                await ctx.send("You must be an admin to use this command")
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.Cog.listener()
     async def on_member_joined(self, ctx, member: discord.Member):
@@ -101,65 +113,73 @@ class Common(commands.Cog, name="general"):
 
     @commands.command(brief="Displays Deadman's Multi-Day Ladder Top 10")
     async def mdl(self, ctx):
-        await ctx.send("Gathering MDL rankings data....")
-        """displays the top 10 on Deadman's MDL"""
-        mdl_url = "http://md-ladder.cloudapp.net/api/v1.0/players/?topk=10"
+        try:
+            await ctx.send("Gathering MDL rankings data....")
+            """displays the top 10 on Deadman's MDL"""
+            mdl_url = "http://md-ladder.cloudapp.net/api/v1.0/players/?topk=10"
 
-        content = urllib.request.urlopen(mdl_url).read()
+            content = urllib.request.urlopen(mdl_url).read()
 
-        data = json.loads(content)
-        mdl_data = "Deadman's Multi-Day Ladder Top 10"
-        mdl_data += "================================="
-        current_player = 1
-        for index, player in enumerate(data['players']):
-            # once we have the players, start printing out each of the top 10
-            mdl_data += (str(current_player) + ") " + player['player_name'] + " Rating:" + str(
-                player['displayed_rating']) + "\n")
-            current_player += 1
+            data = json.loads(content)
+            mdl_data = "Deadman's Multi-Day Ladder Top 10"
+            mdl_data += "================================="
+            current_player = 1
+            for index, player in enumerate(data['players']):
+                # once we have the players, start printing out each of the top 10
+                mdl_data += (str(current_player) + ") " + player['player_name'] + " Rating:" + str(
+                    player['displayed_rating']) + "\n")
+                current_player += 1
 
-        await ctx.send(mdl_data)
+            await ctx.send(mdl_data)
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     @commands.command(brief="Displays all Warzone ladder rankings")
     async def ladders(self, ctx):
-        await ctx.send("Gathering ladder rankings data....")
-        """displays the top 10 on all WL ladders"""
-        ladder_pageurls = ['https://www.warzone.com/LadderSeason?ID=0', 'http://www.warzone.com/LadderSeason?ID=1',
-                           'https://www.warzone.com/LadderSeason?ID=4']
-        for ladder_pageurl in ladder_pageurls:
-            ladder_page = urllib.request.urlopen(ladder_pageurl)
-            soup = BeautifulSoup(ladder_page, 'html.parser')
-            tables = soup.find_all('table')
+        try:
+            await ctx.send("Gathering ladder rankings data....")
+            """displays the top 10 on all WL ladders"""
+            ladder_pageurls = ['https://www.warzone.com/LadderSeason?ID=0', 'http://www.warzone.com/LadderSeason?ID=1',
+                               'https://www.warzone.com/LadderSeason?ID=4']
+            for ladder_pageurl in ladder_pageurls:
+                ladder_page = urllib.request.urlopen(ladder_pageurl)
+                soup = BeautifulSoup(ladder_page, 'html.parser')
+                tables = soup.find_all('table')
 
-            header_str = soup.title.string.split("-")
-            for table in tables:
-                data = "__" + header_str[0].strip() + "__"
-                rows = table.find_all('tr')
-                for row in rows:
-                    columns = row.find_all('td')
-                    for column in columns:
-                        if column.contents[0].strip() and "Rank" in column.contents[0].strip():
-                            found_table = True
-                            break
-                        elif len(columns) == 3:
-                            rating_column = columns[2]
-                            team_column = columns[1]
-                            data = columns[0].contents[0].strip()
-                            data += ") "
-                            current_link = 0
-                            for link in team_column.find_all('a'):
-                                if "LadderTeam" in link.get('href'):
-                                    if (link.contents[0].strip()) != "":
-                                        data += link.contents[0].strip() + " "
-                                    current_link += 1
-                                    if (current_link > 1) and (current_link < len(columns)):
-                                        data += "/ "
+                header_str = soup.title.string.split("-")
+                for table in tables:
+                    data = "__" + header_str[0].strip() + "__"
+                    rows = table.find_all('tr')
+                    for row in rows:
+                        columns = row.find_all('td')
+                        for column in columns:
+                            if column.contents[0].strip() and "Rank" in column.contents[0].strip():
+                                found_table = True
+                                break
+                            elif len(columns) == 3:
+                                rating_column = columns[2]
+                                team_column = columns[1]
+                                data = columns[0].contents[0].strip()
+                                data += ") "
+                                current_link = 0
+                                for link in team_column.find_all('a'):
+                                    if "LadderTeam" in link.get('href'):
+                                        if (link.contents[0].strip()) != "":
+                                            data += link.contents[0].strip() + " "
+                                        current_link += 1
+                                        if (current_link > 1) and (current_link < len(columns)):
+                                            data += "/ "
 
-                            data += " Rating: " + rating_column.contents[0]
-                    await ctx.send(data)
-                if found_table:
-                    found_table = False
-                    await ctx.send("====================================================")
-                    break
+                                data += " Rating: " + rating_column.contents[0]
+                        await ctx.send(data)
+                    if found_table:
+                        found_table = False
+                        await ctx.send("====================================================")
+                        break
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
 
 def setup(bot):

--- a/wlct/cogs/common.py
+++ b/wlct/cogs/common.py
@@ -12,10 +12,11 @@ import datetime
 from django.core.paginator import Paginator
 
 
-def has_admin_role(roles):
-    for role in roles:
-        if role.name == "clot-admin" or role.name == "admin":
-            return True
+def has_admin_access(discord_id):
+    # B/Cowboy/Justin's ID
+    admins = ["288807658264330242", "199018621098262528", "162968893177069568"]
+    if str(discord_id) in admins:
+        return True
     return False
 
 def is_admin(discord_id):

--- a/wlct/cogs/ladders.py
+++ b/wlct/cogs/ladders.py
@@ -1,6 +1,7 @@
 import discord
 from wlct.models import Clan, Player
 from wlct.tournaments import Tournament, TournamentTeam, TournamentPlayer, MonthlyTemplateRotation, get_games_finished_for_team_since, find_tournament_by_id, get_team_data_no_clan, RealTimeLadder, get_real_time_ladder, TournamentGame
+from wlct.logging import log_exception
 from discord.ext import commands, tasks
 from wlct.cogs.common import is_admin
 from django.utils import timezone
@@ -26,117 +27,121 @@ class Ladders(commands.Cog, name="ladders"):
                    ''')
 
     async def rtl(self, ctx, arg_id="invalid_id", arg_cmd="invalid_cmd", arg_cmd2="invalid_cmd2"):
-        print("Arguments for RTL id: {} command: {}".format(arg_id, arg_cmd))
-        invalid_cmd_text = "You've entered an invalid command. Use ``bb!help rtl`` to see list of commands."
-        retStr = ""
-        do_embed = False
-        do_all_channels = False
-        embed_name = ""
-        if arg_id != "invalid_id":
-            emb = discord.Embed(color=self.bot.embed_color)
-            emb.set_author(icon_url=ctx.message.author.avatar_url, name=ctx.message.author)
-            emb.set_footer(text="Bot created and maintained by -B#0292")
-            if arg_id.isnumeric():
-                ladder = get_real_time_ladder(int(arg_id))
-                discord_id = ctx.message.author.id
-                if ladder is not None:
-                    if arg_cmd == "-p":
-                        # display current players in the ladder
-                        retStr = ladder.get_current_joined()
-                    elif arg_cmd == "-j":
-                        retStr = ladder.join_ladder(discord_id, False)
-                        current_joined = ladder.get_current_joined()
-                        retStr += "\n\n" + current_joined + "\n"
-                        await self.send_ladder_message(current_joined, False, ctx.message)
-                    elif arg_cmd == "-jl":
-                        retStr = ladder.join_ladder(discord_id, True) + " (You will be removed once a game is created)"
-                        current_joined = ladder.get_current_joined()
-                        retStr += "\n\n" + current_joined + "\n"
-                        await self.send_ladder_message(current_joined, False, ctx.message)
-                    elif arg_cmd == "-l":
-                        retStr = ladder.leave_ladder(discord_id)
-                        current_joined = ladder.get_current_joined()
-                        retStr += "\n\n" + current_joined + "\n"
-                        await self.send_ladder_message(current_joined, False, ctx.message)
-                    elif arg_cmd == "-t":
-                        retStr = ladder.get_current_templates()
-                        do_embed = True
-                        emb.title = "Current Templates - Ladder {}".format(ladder.name)
-                        emb.add_field(name="Templates", value=retStr)
-                    elif arg_cmd == "-r":
-                        retStr = ladder.get_current_rankings()
-                    elif arg_cmd == "-g":
-                        do_embed = True
-                        retStr = ladder.get_current_games()
-                        if not retStr[0]:
-                            do_embed = False
-                            retStr = retStr[1]
-                        else:
-                            game_data = retStr[1][0]
-                            finished_game_data = retStr[1][1]
-                            print("GameData: {}, Finished Data: {}".format(game_data, finished_game_data))
-                            emb.title = "Games - Ladder {}".format(ladder.name)
-                            if len(game_data) > 0:
-                                emb.add_field(name="In Progress", value=game_data)
-                            if len(finished_game_data) > 0:
-                                emb.add_field(name="Last 10 games", value=finished_game_data)
-                    elif arg_cmd == "-v":
-                        if arg_cmd2 != "invalid_cmd2":
-                            retStr = ladder.veto_template(discord_id, arg_cmd2)
-                        else:
-                            # display the users current veto
-                            retStr = ladder.get_current_vetoes(discord_id)
-                    elif arg_cmd == "-ta":
-                        if arg_cmd2 != "invalid_cmd2":
-                            # check to make sure the author has access here
-                            if is_admin(ctx.message.author.id):
-                                retStr = ladder.add_template(arg_cmd2)
-                        else:
-                            retStr = invalid_cmd_text
-                    elif arg_cmd == "-tr":
-                        if arg_cmd2 != "invalid_cmd2":
-                            # check for access
-                            if is_admin(ctx.message.author.id):
-                                retStr = ladder.remove_template(arg_cmd2)
-                        else:
-                            retStr = invalid_cmd_text
-                    elif arg_cmd == "-me":
-                        # me data returns a tuple of information
-                        # first is what rank/position you are
-                        # second is your last 10 games
-                        me_data =  ladder.get_player_data(discord_id)
-                        if me_data[0]: # success
-                            retStr = me_data[1]
-                            print("Me Data".format(retStr))
-                            emb.title = "Ladder Stats".format(ladder.name)
-                            emb.add_field(name="Performance", value=retStr)
+        try:
+            print("Arguments for RTL id: {} command: {}".format(arg_id, arg_cmd))
+            invalid_cmd_text = "You've entered an invalid command. Use ``bb!help rtl`` to see list of commands."
+            retStr = ""
+            do_embed = False
+            do_all_channels = False
+            embed_name = ""
+            if arg_id != "invalid_id":
+                emb = discord.Embed(color=self.bot.embed_color)
+                emb.set_author(icon_url=ctx.message.author.avatar_url, name=ctx.message.author)
+                emb.set_footer(text="Bot created and maintained by -B#0292")
+                if arg_id.isnumeric():
+                    ladder = get_real_time_ladder(int(arg_id))
+                    discord_id = ctx.message.author.id
+                    if ladder is not None:
+                        if arg_cmd == "-p":
+                            # display current players in the ladder
+                            retStr = ladder.get_current_joined()
+                        elif arg_cmd == "-j":
+                            retStr = ladder.join_ladder(discord_id, False)
+                            current_joined = ladder.get_current_joined()
+                            retStr += "\n\n" + current_joined + "\n"
+                            await self.send_ladder_message(current_joined, False, ctx.message)
+                        elif arg_cmd == "-jl":
+                            retStr = ladder.join_ladder(discord_id, True) + " (You will be removed once a game is created)"
+                            current_joined = ladder.get_current_joined()
+                            retStr += "\n\n" + current_joined + "\n"
+                            await self.send_ladder_message(current_joined, False, ctx.message)
+                        elif arg_cmd == "-l":
+                            retStr = ladder.leave_ladder(discord_id)
+                            current_joined = ladder.get_current_joined()
+                            retStr += "\n\n" + current_joined + "\n"
+                            await self.send_ladder_message(current_joined, False, ctx.message)
+                        elif arg_cmd == "-t":
+                            retStr = ladder.get_current_templates()
                             do_embed = True
+                            emb.title = "Current Templates - Ladder {}".format(ladder.name)
+                            emb.add_field(name="Templates", value=retStr)
+                        elif arg_cmd == "-r":
+                            retStr = ladder.get_current_rankings()
+                        elif arg_cmd == "-g":
+                            do_embed = True
+                            retStr = ladder.get_current_games()
+                            if not retStr[0]:
+                                do_embed = False
+                                retStr = retStr[1]
+                            else:
+                                game_data = retStr[1][0]
+                                finished_game_data = retStr[1][1]
+                                print("GameData: {}, Finished Data: {}".format(game_data, finished_game_data))
+                                emb.title = "Games - Ladder {}".format(ladder.name)
+                                if len(game_data) > 0:
+                                    emb.add_field(name="In Progress", value=game_data)
+                                if len(finished_game_data) > 0:
+                                    emb.add_field(name="Last 10 games", value=finished_game_data)
+                        elif arg_cmd == "-v":
+                            if arg_cmd2 != "invalid_cmd2":
+                                retStr = ladder.veto_template(discord_id, arg_cmd2)
+                            else:
+                                # display the users current veto
+                                retStr = ladder.get_current_vetoes(discord_id)
+                        elif arg_cmd == "-ta":
+                            if arg_cmd2 != "invalid_cmd2":
+                                # check to make sure the author has access here
+                                if is_admin(ctx.message.author.id):
+                                    retStr = ladder.add_template(arg_cmd2)
+                            else:
+                                retStr = invalid_cmd_text
+                        elif arg_cmd == "-tr":
+                            if arg_cmd2 != "invalid_cmd2":
+                                # check for access
+                                if is_admin(ctx.message.author.id):
+                                    retStr = ladder.remove_template(arg_cmd2)
+                            else:
+                                retStr = invalid_cmd_text
+                        elif arg_cmd == "-me":
+                            # me data returns a tuple of information
+                            # first is what rank/position you are
+                            # second is your last 10 games
+                            me_data =  ladder.get_player_data(discord_id)
+                            if me_data[0]: # success
+                                retStr = me_data[1]
+                                print("Me Data".format(retStr))
+                                emb.title = "Ladder Stats".format(ladder.name)
+                                emb.add_field(name="Performance", value=retStr)
+                                do_embed = True
+                            else:
+                                # error
+                                retStr = me_data[1]
                         else:
-                            # error
-                            retStr = me_data[1]
+                            retStr = invalid_cmd_text
                     else:
-                        retStr = invalid_cmd_text
+                        retStr = "You've entered an invalid ladder ID."
                 else:
                     retStr = "You've entered an invalid ladder ID."
+            elif arg_id == "invalid_id":
+                retStr += "__**Current Real-Time Ladders**__\n"
+                ladders = RealTimeLadder.objects.all()
+                if not ladders or ladders.count() == 0:
+                    retStr += "There are no real-time ladders created yet."
+                else:
+                    for ladder in ladders:
+                        retStr += "{} | Id: {}".format(ladder.name, ladder.id)
             else:
-                retStr = "You've entered an invalid ladder ID."
-        elif arg_id == "invalid_id":
-            retStr += "__**Current Real-Time Ladders**__\n"
-            ladders = RealTimeLadder.objects.all()
-            if not ladders or ladders.count() == 0:
-                retStr += "There are no real-time ladders created yet."
-            else:
-                for ladder in ladders:
-                    retStr += "{} | Id: {}".format(ladder.name, ladder.id)
-        else:
-            retStr = invalid_cmd_text
+                retStr = invalid_cmd_text
 
-        if do_embed:
-            print("Sending embed")
-            await ctx.send(embed=emb)
-        else:
-            print("Sending real message")
-            await ctx.send(retStr)
+            if do_embed:
+                print("Sending embed")
+                await ctx.send(embed=emb)
+            else:
+                print("Sending real message")
+                await ctx.send(retStr)
+        except:
+            log_exception()
+            await ctx.send("An error has occurred and was unable to process the command.")
 
     '''
     Sends updates to guilds that are not guild_original_msg.

--- a/wlct/cogs/ladders.py
+++ b/wlct/cogs/ladders.py
@@ -12,20 +12,24 @@ class Ladders(commands.Cog, name="ladders"):
     def __init__(self, bot):
         self.bot = bot
 
+    usage = '''
+           109 -j : joins ladder 109
+           109 -l : leaves ladder 109
+           109 -jl : joins ladder 109 for single game
+           109 -h : displays help with all commands
+           109 -t : displays all templates on the ladder
+           109 -p : displays all players currently on the ladder
+           109 -r : displays full ladder rankings
+           109 -g : displays all in progress games
+           109 -v <templateid>: vetoes a template or displays the current one if no template id is passed
+           109 -me : displays information about yourself on the ladder
+           '''
+
     @commands.command(brief="Lists all real-time ladders hosted by this bot and their IDs",
-             usage='''
-                   109 -j : joins ladder 109
-                   109 -l : leaves ladder 109
-                   109 -t : displays all templates on the ladder
-                   109 -p : displays all players currently on the ladder
-                   109 -r : displays full ladder rankings
-                   109 -g : displays all in progress games
-                   109 -v templateid: vetoes a template or displays the current one if no template id is passed
-                   109 -me : displays information about yourself on the ladder
-                   ''')
+             usage=usage)
     async def rtl(self, ctx, arg_id="invalid_id", arg_cmd="invalid_cmd", arg_cmd2="invalid_cmd2"):
         print("Arguments for RTL id: {} command: {}".format(arg_id, arg_cmd))
-        invalid_cmd_text = "You've entered an invalid command. Please correct it and try again."
+        invalid_cmd_text = "You've entered an invalid command. Use ``bb!rtl 109 -h`` to see list of commands."
         retStr = ""
         do_embed = False
         do_all_channels = False
@@ -37,7 +41,7 @@ class Ladders(commands.Cog, name="ladders"):
             if arg_id.isnumeric():
                 ladder = get_real_time_ladder(int(arg_id))
                 discord_id = ctx.message.author.id
-                if ladder is not None:
+                if ladder is None:
                     if arg_cmd == "-p":
                         # display current players in the ladder
                         retStr = ladder.get_current_joined()
@@ -56,6 +60,11 @@ class Ladders(commands.Cog, name="ladders"):
                         current_joined = ladder.get_current_joined()
                         retStr += "\n\n" + current_joined + "\n"
                         await self.send_ladder_message(current_joined, False, ctx.message)
+                    elif arg_cmd == "-h":
+                        retStr = self.usage
+                        do_embed = True
+                        #emb.title = "Help - Ladder {}".format(ladder.name)
+                        emb.add_field(name="Help", value=retStr)
                     elif arg_cmd == "-t":
                         retStr = ladder.get_current_templates()
                         do_embed = True

--- a/wlct/cogs/ladders.py
+++ b/wlct/cogs/ladders.py
@@ -16,7 +16,6 @@ class Ladders(commands.Cog, name="ladders"):
            109 -j : joins ladder 109
            109 -l : leaves ladder 109
            109 -jl : joins ladder 109 for single game
-           109 -h : displays help with all commands
            109 -t : displays all templates on the ladder
            109 -p : displays all players currently on the ladder
            109 -r : displays full ladder rankings
@@ -29,7 +28,7 @@ class Ladders(commands.Cog, name="ladders"):
              usage=usage)
     async def rtl(self, ctx, arg_id="invalid_id", arg_cmd="invalid_cmd", arg_cmd2="invalid_cmd2"):
         print("Arguments for RTL id: {} command: {}".format(arg_id, arg_cmd))
-        invalid_cmd_text = "You've entered an invalid command. Use ``bb!rtl 109 -h`` to see list of commands."
+        invalid_cmd_text = "You've entered an invalid command. Use ``bb!help rtl`` to see list of commands."
         retStr = ""
         do_embed = False
         do_all_channels = False
@@ -60,11 +59,6 @@ class Ladders(commands.Cog, name="ladders"):
                         current_joined = ladder.get_current_joined()
                         retStr += "\n\n" + current_joined + "\n"
                         await self.send_ladder_message(current_joined, False, ctx.message)
-                    elif arg_cmd == "-h":
-                        retStr = self.usage
-                        do_embed = True
-                        #emb.title = "Help - Ladder {}".format(ladder.name)
-                        emb.add_field(name="Help", value=retStr)
                     elif arg_cmd == "-t":
                         retStr = ladder.get_current_templates()
                         do_embed = True
@@ -136,7 +130,7 @@ class Ladders(commands.Cog, name="ladders"):
                 for ladder in ladders:
                     retStr += "{} | Id: {}".format(ladder.name, ladder.id)
         else:
-            retStr = "You have entered an invalid command. Please correct it and try again."
+            retStr = invalid_cmd_text
 
         if do_embed:
             print("Sending embed")

--- a/wlct/cogs/ladders.py
+++ b/wlct/cogs/ladders.py
@@ -12,20 +12,19 @@ class Ladders(commands.Cog, name="ladders"):
     def __init__(self, bot):
         self.bot = bot
 
-    usage = '''
-           109 -j : joins ladder 109
-           109 -l : leaves ladder 109
-           109 -jl : joins ladder 109 for single game
-           109 -t : displays all templates on the ladder
-           109 -p : displays all players currently on the ladder
-           109 -r : displays full ladder rankings
-           109 -g : displays all in progress games
-           109 -v <templateid>: vetoes a template or displays the current one if no template id is passed
-           109 -me : displays information about yourself on the ladder
-           '''
-
     @commands.command(brief="Lists all real-time ladders hosted by this bot and their IDs",
-             usage=usage)
+             usage='''
+                   109 -j : joins ladder 109
+                   109 -l : leaves ladder 109
+                   109 -jl : joins ladder 109 for single game
+                   109 -t : displays all templates on the ladder
+                   109 -p : displays all players currently on the ladder
+                   109 -r : displays full ladder rankings
+                   109 -g : displays all in progress games
+                   109 -v <templateid>: vetoes a template or displays the current one if no template id is passed
+                   109 -me : displays information about yourself on the ladder
+                   ''')
+
     async def rtl(self, ctx, arg_id="invalid_id", arg_cmd="invalid_cmd", arg_cmd2="invalid_cmd2"):
         print("Arguments for RTL id: {} command: {}".format(arg_id, arg_cmd))
         invalid_cmd_text = "You've entered an invalid command. Use ``bb!help rtl`` to see list of commands."
@@ -40,7 +39,7 @@ class Ladders(commands.Cog, name="ladders"):
             if arg_id.isnumeric():
                 ladder = get_real_time_ladder(int(arg_id))
                 discord_id = ctx.message.author.id
-                if ladder is None:
+                if ladder is not None:
                     if arg_cmd == "-p":
                         # display current players in the ladder
                         retStr = ladder.get_current_joined()

--- a/wlct/models.py
+++ b/wlct/models.py
@@ -22,11 +22,6 @@ class DiscordUser(models.Model):
     def __str__(self):
         return "Member: {}, LinkMention: {}".format(self.memberid, self.link_mention)
 
-class DiscordChannelRTLadderLink(models.Model):
-    rtladder = models.ForeignKey('RealTimeLadder', on_delete=models.CASCADE, blank=True, null=True)
-    channelid = models.BigIntegerField(default=0, blank=True, null=True, db_index=True)
-    discord_user = models.ForeignKey('DiscordUser', blank=True, null=True, on_delete=models.CASCADE)
-
 class DiscordChannelTournamentLink(models.Model):
     tournament = models.ForeignKey('Tournament', on_delete=models.CASCADE, blank=True, null=True)
     channelid = models.BigIntegerField(default=0, blank=True, null=True, db_index=True)

--- a/wlct/models.py
+++ b/wlct/models.py
@@ -22,6 +22,11 @@ class DiscordUser(models.Model):
     def __str__(self):
         return "Member: {}, LinkMention: {}".format(self.memberid, self.link_mention)
 
+class DiscordChannelRTLadderLink(models.Model):
+    rtladder = models.ForeignKey('RealTimeLadder', on_delete=models.CASCADE, blank=True, null=True)
+    channelid = models.BigIntegerField(default=0, blank=True, null=True, db_index=True)
+    discord_user = models.ForeignKey('DiscordUser', blank=True, null=True, on_delete=models.CASCADE)
+
 class DiscordChannelTournamentLink(models.Model):
     tournament = models.ForeignKey('Tournament', on_delete=models.CASCADE, blank=True, null=True)
     channelid = models.BigIntegerField(default=0, blank=True, null=True, db_index=True)

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -259,6 +259,19 @@ def find_league_by_id(id):
         log_exception()
         log("League wasn't found: {}".format(id), LogLevel.informational)
 
+def find_tournaments_by_division_id(id):
+    try:
+        division = ClanLeagueDivision.objects.filter(pk=id)
+        if division:
+            return ClanLeagueTournament.objects.filter(division=division[0])
+
+    except:
+        # tournament wasn't found
+        log_exception()
+        log("Tournament wasn't found: {}".format(id), LogLevel.informational)
+
+    return []
+
 def find_tournament_by_id(id, query_all=False):
     try:
         # try to get the tournament that has this id


### PR DESCRIPTION
PR adds various commands to the discord bot. Also fixed up messages on all commands for help.

Admin commands:

- bb!admin logs -- not completed yet
- bb!admin mtc -p -- lists all players on the MTC (w/ wz token)
- bb!admin mtc -r <token> -- removes a player from the MTC using their wz token
- bb!admin rtl -p -- lists all players on the RTL (w/ discord id)
- bb!admin rtl -r <discord_id> -- removes player from the RTL using discord id

Global commands:
- bb!linkd -a <division_id> -- links all tournaments in the division to the channel (individual tournament links)
- bb!linkd -r <division_id> -- removes links to all tournaments in the division from the channel
- bb!divisions -- lists all CL divisions with their IDs