### PR TITLE
Copy Season Button on PR Leagues

### DIFF
--- a/wlct/templates/pr.html
+++ b/wlct/templates/pr.html
@@ -37,8 +37,7 @@
                     Only)
                 </button><hr>
                 {% endif %}
-
-    {% if tournament.created_by.token == request.session.token and not tournament.has_started %}
+    {% if tournament.created_by.token == request.session.token %}
             <!-- Modal to display after pressing the 'copy season' button on the P/R league overview page -->
             <div class="modal" tabindex="-1" role="dialog" id="copy-season-modal">
                 <div class="modal-dialog modal-lg" role="document">
@@ -62,6 +61,9 @@
                     </div>
                 </div>
             </div>
+    {% endif %}
+
+    {% if tournament.created_by.token == request.session.token and not tournament.has_started %}
             <div class="card gedf-card span8">
                 <div class="card-header">
                     <div class="d-flex justify-content-between align-items-center">

--- a/wlct/templates/pr.html
+++ b/wlct/templates/pr.html
@@ -39,6 +39,29 @@
                 {% endif %}
 
     {% if tournament.created_by.token == request.session.token and not tournament.has_started %}
+            <!-- Modal to display the start_locked_data for the tournament -->
+            <div class="modal" tabindex="-1" role="dialog" id="copy-season-modal">
+                <div class="modal-dialog modal-lg" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="copy-season-title"></h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                        <div class="modal-body" id="tournament_start_request_text" style="overflow-y:auto;">
+                            <div class="input-group">
+                                <label class="col-form-label" for="copy-season-name-text"><b>Season Name: &nbsp;</b></label>
+                                <input type="text" class="form-control mb-4" placeholder="Season Name" name="copy-season-name" id="copy-season-name" />
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-primary" id="copy-season-button" data="">Copy Season</button>
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="card gedf-card span8">
                 <div class="card-header">
                     <div class="d-flex justify-content-between align-items-center">

--- a/wlct/templates/pr.html
+++ b/wlct/templates/pr.html
@@ -39,7 +39,7 @@
                 {% endif %}
 
     {% if tournament.created_by.token == request.session.token and not tournament.has_started %}
-            <!-- Modal to display the start_locked_data for the tournament -->
+            <!-- Modal to display after pressing the 'copy season' button on the P/R league overview page -->
             <div class="modal" tabindex="-1" role="dialog" id="copy-season-modal">
                 <div class="modal-dialog modal-lg" role="document">
                     <div class="modal-content">
@@ -49,7 +49,7 @@
                                 <span aria-hidden="true">&times;</span>
                             </button>
                         </div>
-                        <div class="modal-body" id="tournament_start_request_text" style="overflow-y:auto;">
+                        <div class="modal-body" id="copy_season_request_text" style="overflow-y:auto;">
                             <div class="input-group">
                                 <label class="col-form-label" for="copy-season-name-text"><b>Season Name: &nbsp;</b></label>
                                 <input type="text" class="form-control mb-4" placeholder="Season Name" name="copy-season-name" id="copy-season-name" />

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -3923,17 +3923,15 @@ class PromotionalRelegationLeague(Tournament):
         # Get original season to copy
         orig_season = PromotionalRelegationLeagueSeason.objects.filter(id=int(copy_season_id))
         # Ensure parameters are correct before copying
-        if  not orig_season:
+        if not orig_season:
             raise ValueError("Seasonal with id {} could not be found".format(copy_season_id))
         # Get the # of games and template from original season
         games_at_once = orig_season[0].games_at_once
-        template = orig_season[0].season_template;
-        if len(season_name) < 3 or len(season_name) > 251:
-            raise ValueError("Season name must be between 3-250 characters.")
-        if games_at_once < 1 or games_at_once > 100:
-            raise ValueError("Games at once must be 1-100 inclusive.")
+        template = orig_season[0].season_template
+        description = orig_season[0].description
+
         # Create a new season given original season
-        season = PromotionalRelegationLeagueSeason(pr_tournament=self, name=season_name, created_by=self.created_by, private=True, games_at_once=games_at_once, season_template=template)
+        season = PromotionalRelegationLeagueSeason(pr_tournament=self, name=season_name, created_by=self.created_by, private=True, games_at_once=games_at_once, season_template=template, game_creation_allowed=False, description=description)
         season.save()
         
         # Iterate through original season divisions and copy to new season
@@ -3942,7 +3940,6 @@ class PromotionalRelegationLeague(Tournament):
             new_division = ClanLeagueDivision(title=div.title, pr_season=season)
             new_division.save()
 
-
             # Iterate through original season teams and copy TT and TP to new season
             teams = TournamentTeam.objects.filter(clan_league_division=div)
             for team in teams:
@@ -3950,14 +3947,12 @@ class PromotionalRelegationLeague(Tournament):
                 new_team.save()
                 players = TournamentPlayer.objects.filter(team=team)
                 for player in players:
-                    new_player = TournamentPlayer(team=new_team, tournament=season, player=players[0].player)
+                    new_player = TournamentPlayer(team=new_team, tournament=season, player=player.player)
                     new_player.save()
-
         # Set player count for season
         players = TournamentPlayer.objects.filter(tournament=season)
         if players:
             season.numbers_players = players.count()
-        season.game_creation_allowed = False
         season.save()
 
     def get_seasons_editable(self):
@@ -3981,7 +3976,7 @@ class PromotionalRelegationLeague(Tournament):
                 if not season.is_finished and season.has_started:
                     disabled = "disabled"
                 mgmt_data += '&nbsp;<button type="button" class="btn btn-md btn-danger remove-pr-season" id="remove-pr-season-{}" data-id="{}" {}>Delete Season</button>'.format(season.id, season.id, disabled)
-                mgmt_data += '&nbsp;<button type="button" class="btn btn-md btn-success copy-pr-season" id="copy-pr-season-{}" data-id="{}">Copy Season</button>'.format(season.id, season.id, disabled)
+                mgmt_data += '&nbsp;<button type="button" class="btn btn-md btn-success copy-pr-season" id="copy-pr-season-{}" data-id="{}">Copy Season</button>'.format(season.id, season.id)
             season_data += '<tr><td id="season-{}">{}</td><td>{}</td></tr>'.format(season.id, season.name, mgmt_data)
         season_data += '</table></div></div>'
 

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -3920,31 +3920,43 @@ class PromotionalRelegationLeague(Tournament):
         season.save()
 
     def copy_season(self, season_name, copy_season_id):
-        seasonal_copy = PromotionalRelegationLeagueSeason.objects.filter(id=int(copy_season_id))
-        if  not seasonal_copy:
+        # Get original season to copy
+        orig_season = PromotionalRelegationLeagueSeason.objects.filter(id=int(copy_season_id))
+        # Ensure parameters are correct before copying
+        if  not orig_season:
             raise ValueError("Seasonal with id {} could not be found".format(copy_season_id))
-        games_at_once = seasonal_copy[0].games_at_once
-        template = seasonal_copy[0].season_template;
+        # Get the # of games and template from original season
+        games_at_once = orig_season[0].games_at_once
+        template = orig_season[0].season_template;
         if len(season_name) < 3 or len(season_name) > 251:
             raise ValueError("Season name must be between 3-250 characters.")
         if games_at_once < 1 or games_at_once > 100:
             raise ValueError("Games at once must be 1-100 inclusive.")
+        # Create a new season given original season
         season = PromotionalRelegationLeagueSeason(pr_tournament=self, name=season_name, created_by=self.created_by, private=True, games_at_once=games_at_once, season_template=template)
         season.save()
-        divisions = ClanLeagueDivision.objects.filter(pr_season=seasonal_copy[0])
+        
+        # Iterate through original season divisions and copy to new season
+        divisions = ClanLeagueDivision.objects.filter(pr_season=orig_season[0])
         for div in divisions:
             new_division = ClanLeagueDivision(title=div.title, pr_season=season)
             new_division.save()
-            # always default to create 4 slots per team in the division
+
+
+            # Iterate through original season teams and copy TT and TP to new season
             teams = TournamentTeam.objects.filter(clan_league_division=div)
             for team in teams:
-                new_team = TournamentTeam(clan_league_division=new_division, max_games_at_once=games_at_once, players=team.players)
+                new_team = TournamentTeam(clan_league_division=new_division, max_games_at_once=games_at_once, players=team.players, tournament=season)
                 new_team.save()
+                players = TournamentPlayer.objects.filter(team=team)
+                for player in players:
+                    new_player = TournamentPlayer(team=new_team, tournament=season, player=players[0].player)
+                    new_player.save()
 
+        # Set player count for season
         players = TournamentPlayer.objects.filter(tournament=season)
         if players:
             season.numbers_players = players.count()
-        # the creator will get to assign players to these team slots now
         season.game_creation_allowed = False
         season.save()
 
@@ -3968,9 +3980,9 @@ class PromotionalRelegationLeague(Tournament):
                 disabled = ""
                 if not season.is_finished and season.has_started:
                     disabled = "disabled"
-                mgmt_data += '&nbsp;<button type="button" class="btn btn-md btn-danger" id="remove-pr-season" data-id="{}" {}>Delete Season</button>'.format(season.id, disabled)
-                mgmt_data += '&nbsp;<button type="button" class="btn btn-md btn-success" id="copy-pr-season" data-id="{}">Copy Season</button>'.format(season.id)
-            season_data += '<tr><td>{}</td><td>{}</td></tr>'.format(season.name, mgmt_data)
+                mgmt_data += '&nbsp;<button type="button" class="btn btn-md btn-danger remove-pr-season" id="remove-pr-season-{}" data-id="{}" {}>Delete Season</button>'.format(season.id, season.id, disabled)
+                mgmt_data += '&nbsp;<button type="button" class="btn btn-md btn-success copy-pr-season" id="copy-pr-season-{}" data-id="{}">Copy Season</button>'.format(season.id, season.id, disabled)
+            season_data += '<tr><td id="season-{}">{}</td><td>{}</td></tr>'.format(season.id, season.name, mgmt_data)
         season_data += '</table></div></div>'
 
         return season_data

--- a/wlct/views.py
+++ b/wlct/views.py
@@ -511,6 +511,8 @@ def pr_update_season(request):
                             tournament.create_season(request.POST['season-name'], request.POST['games-at-once'])
                         elif request.POST['type'] == "remove":
                             tournament.remove_season(request.POST['season_id'])
+                        elif request.POST['type'] == "copy":
+                            tournament.copy_season(request.POST['season-name'], request.POST['season_id']);
 
                         context.update({'success': 'true'})
                         context.update({'season_data': tournament.get_seasons_editable()})

--- a/wltourney/static/js/tournament.js
+++ b/wltourney/static/js/tournament.js
@@ -342,20 +342,33 @@ function update_division(type, obj)
         });
 }
 
+function show_copy_season_modal(obj)
+{
+    $('#copy-season-modal').modal('show');
+    $('#copy-season-title').text(`Copy ${obj.data('id')}?`);
+    $('#copy-season-button').data('id', obj.data('id'));
+}
+
 function update_pr_season(obj, type)
 {
     var tournamentid = $("#tournamentid").val();
     var old_text_value = obj.text();
-    var data = {"tournamentid": tournamentid, "season-name": $("#season-name").val(), "games-at-once": $("#games-at-once").val(), "type" : type};
+    var data = {"tournamentid": tournamentid, "type" : type};
 
     if (type == "add")
     {
         show_spinning(obj, "Creating New Season...");
+        data["season-name"] = $("#season-name").val();
+        data["games-at-once"] = $("#games-at-once").val();
     }
     else if (type == "remove")
     {
         show_spinning(obj, "Deleting Season...");
         data["season_id"] = obj.data('id');
+    } else if (type == "copy") {
+        data["season-name"] = $("#copy-season-name").val();
+        data["season_id"] = obj.data('id');
+
     }
     var url = "/pr/seasons/update/";
 
@@ -368,6 +381,8 @@ function update_pr_season(obj, type)
                 // populate the new list of seasons
                 $("#pr-season-tab").html(data.season_data);
                 $("#season-name").val('');
+                $("#copy-season-modal").modal('hide');
+                $("#copy-season-name").val('');
             }
             else
             {
@@ -399,6 +414,16 @@ function hook_pr_buttons()
     $("#remove-pr-season").on('click', function()
     {
         update_pr_season(jQuery(this), "remove");
+    });
+
+    $("#copy-pr-season").on('click', function()
+    {
+        show_copy_season_modal(jQuery(this));
+    });
+
+    $("#copy-season-button").on('click', function()
+    {
+        update_pr_season(jQuery(this), "copy");
     });
 
     $("button[id^=division-add-team").on('click', function()

--- a/wltourney/static/js/tournament.js
+++ b/wltourney/static/js/tournament.js
@@ -344,8 +344,9 @@ function update_division(type, obj)
 
 function show_copy_season_modal(obj)
 {
+    let seasonName = $(`#season-${obj.data('id')}`).html();
     $('#copy-season-modal').modal('show');
-    $('#copy-season-title').text(`Copy ${obj.data('id')}?`);
+    $('#copy-season-title').text(`Copy ${seasonName}?`);
     $('#copy-season-button').data('id', obj.data('id'));
 }
 
@@ -368,7 +369,6 @@ function update_pr_season(obj, type)
     } else if (type == "copy") {
         data["season-name"] = $("#copy-season-name").val();
         data["season_id"] = obj.data('id');
-
     }
     var url = "/pr/seasons/update/";
 
@@ -411,12 +411,12 @@ function hook_pr_buttons()
         update_pr_season(jQuery(this), "add");
     });
 
-    $("#remove-pr-season").on('click', function()
+    $(".remove-pr-season").on('click', function()
     {
         update_pr_season(jQuery(this), "remove");
     });
 
-    $("#copy-pr-season").on('click', function()
+    $(".copy-pr-season").on('click', function()
     {
         show_copy_season_modal(jQuery(this));
     });


### PR DESCRIPTION
PR adds changes to the P/R overview page to include a 'copy season' button. This will copy the template, divisions and players from the selected season into a new season.

This also changes the season remove/copy buttons to use unique IDs and adds listener to the class field instead. (Addresses bug with only first season in list being deletable)

P/R Overview Page:
![image](https://user-images.githubusercontent.com/61162841/80644439-a425da80-8a37-11ea-8b0a-12cae38a6049.png)

Copy Modal:
![image](https://user-images.githubusercontent.com/61162841/80644473-b273f680-8a37-11ea-8599-66220597618e.png)
