### PR TITLE
Prevent embed overflow and encode print statements

### DIFF
--- a/wlct/cogs/clot.py
+++ b/wlct/cogs/clot.py
@@ -922,6 +922,13 @@ class Clot(commands.Cog, name="clot"):
                         if current_player % 10 == 0:
                             emb.add_field(name=field_name, value=player_data)
                             player_data = ""  # reset this for the next embed
+
+                        if len(emb) > 5000:
+                            await ctx.send(embed=emb)
+                            emb = discord.Embed(color=self.bot.embed_color)
+                            emb.title = "{}".format(clan_obj[0].name)
+                            emb.set_thumbnail(url=clan_obj[0].image_path)
+
                     if len(player_data) > 0:
                         emb.add_field(name=field_name, value=player_data)
                     await ctx.send(embed=emb)

--- a/wlct/cogs/tasks.py
+++ b/wlct/cogs/tasks.py
@@ -412,7 +412,7 @@ class Tasks(commands.Cog, name="tasks"):
                 discord_user = discord_user[0]
 
             if not discord_user.link_mention:
-                print("Sending welcome message to {}".format(member.name))
+                print("Sending welcome message to {}".format(member.name.encode('utf-8')))
                 await member.send(embed=emb)
                 discord_user.link_mention = True
                 discord_user.save()

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -148,7 +148,7 @@ def get_team_data_no_clan(team):
     team_data = ""
     tournament_players = TournamentPlayer.objects.filter(team=team)
     for tournament_player in tournament_players:
-        team_data += '{} '.format(tournament_player.player.name)
+        team_data += '{} '.format(tournament_player.player.name.encode('utf-8'))
     return team_data
 
 def get_team_data_no_clan_player_list(list):


### PR DESCRIPTION
Fixes minor bugs in discord commands. Prevents the bb!clan command from overflowing the embed. Will wrap overflowing text to successive embed messages. PR also adds encoding to name values used in prints.