### PR TITLE
Minor CLOT features

### DIFF
--- a/wlct/cogs/clot.py
+++ b/wlct/cogs/clot.py
@@ -881,7 +881,7 @@ class Clot(commands.Cog, name="clot"):
                         if games_finished >= 10:
                             tournament_data += "{}) {} - {}\n".format(teams_found + 1, get_team_data_no_clan(team), team.rating)
                             teams_found += 1
-                print("MTC: {}\nLength: {}".format(tournament_data, len(tournament_data)))
+                print("MTC: {}\nLength: {}".format(tournament_data.encode('utf-8'), len(tournament_data)))
                 await ctx.send(tournament_data)
             else:
                 await ctx.send("You've entered an invalid MTC league id.")

--- a/wlct/templates/pr_season.html
+++ b/wlct/templates/pr_season.html
@@ -33,6 +33,10 @@
             <div class="card-body">
                 <input type="hidden" id="template-warning">
                 <input type="hidden" value="{{ tournament.id }}" id="tournamentid">
+                {% if tournament.pr_tournament %}
+                    <b>League:</b> <a class="badge badge-primary" href="/leagues/{{ tournament.pr_tournament.id }}">{{ tournament.pr_tournament.name }}</a>
+                    <br/><br/>
+                {% endif %}
                 {% if tournament.created_by.token == request.session.token %}
                 {% if not tournament.has_started %}
                 {% if tournament.can_start_tourney %}

--- a/wlct/templates/tournament.html
+++ b/wlct/templates/tournament.html
@@ -58,6 +58,13 @@
                 <br/><br/>
                 {% endif %}
                 <p class="card-text h7">
+                    {% if tournament.clan_league_template %}
+                        <b>Clan League:</b> <a class="badge badge-primary" href="/leagues/{{ tournament.parent_tournament.id }}">{{ tournament.parent_tournament.name }}</a>
+                        <br/>
+                    {% elif tournament.parent_tournament %}
+                        <b>Season:</b> <a class="badge badge-primary" href="/pr/season/{{ tournament.parent_tournament.id }}">{{ tournament.parent_tournament.name }}</a>
+                        <br/>
+                    {% endif %}
                     <b>Tournament Description</b>&nbsp;<a
                         href="https://warzone.com/MultiPlayer?TemplateID={{ tournament.template }}" target="_blank"
                         class="badge badge-primary">Click to create game with template settings</a>

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -148,7 +148,7 @@ def get_team_data_no_clan(team):
     team_data = ""
     tournament_players = TournamentPlayer.objects.filter(team=team)
     for tournament_player in tournament_players:
-        team_data += '{} '.format(tournament_player.player.name.encode('utf-8'))
+        team_data += '{} '.format(tournament_player.player.name)
     return team_data
 
 def get_team_data_no_clan_player_list(list):

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -796,6 +796,8 @@ class Tournament(models.Model):
     def get_url(self):
         if self.is_league:
             return "/leagues/{}/".format(self.id)
+        elif hasattr(self, "season_template"):
+            return "/pr/season/{}/".format(self.id)
         return "/tournaments/{}/".format(self.id)
 
     def are_vacations_supported(self):
@@ -4282,6 +4284,11 @@ class PromotionalRelegationLeagueSeason(Tournament):
                 tplayer = TournamentPlayer.objects.get(id=int(playerid))
                 templateid = self.season_template.templateid
                 player = Player.objects.get(id=int(request_data['data_attrib[swapid]']))
+
+                # Check if the player is already in the tournament (only applies if not empty seat -- ie token != "1")
+                if player.token != "1" and TournamentPlayer.objects.filter(player=player, tournament=self):
+                    raise Exception("{} is already invited.".format(player.name))
+
                 if is_player_allowed_join(player, templateid):
                     log_tournament(
                         "Swapped {} [{}] with {} [{}]".format(tplayer.player.name, tplayer.player.token, player.name,

--- a/wlct/views.py
+++ b/wlct/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseRedirect, HttpResponse
 from wlct.form_message_handling import FormError
 from wlct.api import API, get_account_token
 from wlct.models import Player, Clan
-from wlct.tournaments import SwissTournament, GroupStageTournament, SeededTournament, TournamentInvite, TournamentPlayer, find_tournament_by_id, Tournament, find_league_by_id, is_player_allowed_join, TournamentGameEntry, get_matchup_data, RealTimeLadder, RoundRobinRandomTeams
+from wlct.tournaments import SwissTournament, GroupStageTournament, SeededTournament, PromotionalRelegationLeagueSeason, TournamentInvite, TournamentPlayer, find_tournament_by_id, Tournament, find_league_by_id, is_player_allowed_join, TournamentGameEntry, get_matchup_data, RealTimeLadder, RoundRobinRandomTeams
 from wlct.forms import SwissTournamentForm, SeededTournamentForm, GroupTournamentForm, MonthlyTemplateCircuitForm, PromotionRelegationLeagueForm, ClanLeagueForm, RoundRobinRandomTeamsForm
 from django.http import JsonResponse
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
@@ -756,6 +756,14 @@ def mytourneys_view(request):
                 if child_league and league.id not in leagues_found:
                     league_list.append(child_league)
                     leagues_found.append(child_league.id)
+
+            # Get PR seasons that players are in (but not the creator)
+            seasons = PromotionalRelegationLeagueSeason.objects.all();
+            for season in seasons:
+                # If player did not create the league and is in a season, add season to list
+                if season.created_by != player and season.id not in leagues_found and TournamentPlayer.objects.filter(tournament=season, player=player):
+                    league_list.append(season)
+                    leagues_found.append(season)
 
             context.update({'leagues': league_list})
             context.update({'tournaments': result_list})


### PR DESCRIPTION
PR adds a couple features to the frontend. Allows for parent-tourney back navigation with links to parent season/league for PR tournaments and clan league from division tournaments. Also adds the PR seasons to "My Tournaments/Leagues" page for tournaments the user is in. PR league creation also has error guards for adding duplicate players.

UTF encoding statement was moved to prevent weird prints.