### PR TITLE
Round Robin Tournament Bye Fix

### DIFF
--- a/wlct/logging.py
+++ b/wlct/logging.py
@@ -25,6 +25,9 @@ class LogLevel:
     api = "API"
     webhook = "Webhook"
 
+def log_critical_msg(msg):
+    log(msg, LogLevel.critical)
+
 def log_exception():
     log(traceback.format_exc(), LogLevel.critical)
 

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -2673,7 +2673,8 @@ class RoundRobinTournament(Tournament):
         # while current_iteration < iterations and iterations < 50:
 
         doAllClansHaveGames = False;
-        while not doAllClansHaveGames:
+        iterations = 0
+        while not doAllClansHaveGames and iterations < 50:
             team_game_data_copy = team_game_data.copy()
             for matchup in possible_matchups:
                 if round:
@@ -2698,6 +2699,7 @@ class RoundRobinTournament(Tournament):
                         game_data2.append(team2)
                         log_tournament("After game was validated, following teams have games created: {}".format(games_created), self)
 
+            print("Teams in list: {}\nTeams created: {}".format(teams_list, games_created))
             # Check if enough games were found... Redo if not
             if len(teams_list) == len(games_created):
                 doAllClansHaveGames = True
@@ -2707,7 +2709,12 @@ class RoundRobinTournament(Tournament):
                 game_data1.clear()
                 game_data2.clear()
                 shuffle(possible_matchups)
-                log_tournament("Missing matchups found. Retrying matchups... Only {} games made containing the teams: {}".format(len(game_data1), games_created), self)
+                log_tournament("Missing matchups found. Retrying matchups... Only {} games were matched containing the teams: {}".format(len(game_data1), games_created), self)
+                iterations += 1
+
+        if iterations == 50:
+            # Was unable to find enough games for tournament... BAD
+            log_tournament("Unable to find game matchups after 50 iterations... Not creating any games", self)
 
         log_tournament("Teams with games created so far: {}, teams in division: {}, byes: {}".format(len(games_created), self.number_teams, self.uses_byes()), self)
         if self.uses_byes():

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.contrib import admin
 import datetime
 from dateutil import tz
-from wlct.logging import log_exception, log, LogLevel, log_tournament, log_game, log_game_status, ProcessGameLog, ProcessNewGamesLog
+from wlct.logging import log_exception, log, LogLevel, log_tournament, log_game, log_game_status, ProcessGameLog, ProcessNewGamesLog,  log_critical_msg
 from wlct.models import Player, Clan
 from django.conf import settings
 import random
@@ -2714,7 +2714,7 @@ class RoundRobinTournament(Tournament):
 
         if iterations == 50:
             # Was unable to find enough games for tournament... BAD
-            log_tournament("Unable to find game matchups after 50 iterations... Not creating any games", self)
+            log_critical_msg("Unable to find game matchups after 50 iterations in {} [ID: {}]".format(self.name, self.id))
 
         log_tournament("Teams with games created so far: {}, teams in division: {}, byes: {}".format(len(games_created), self.number_teams, self.uses_byes()), self)
         if self.uses_byes():

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -2672,9 +2672,8 @@ class RoundRobinTournament(Tournament):
         round = TournamentRound.objects.filter(tournament=self, round_number=1)
         # while current_iteration < iterations and iterations < 50:
 
-        doAllClansHaveGames = False;
         iterations = 0
-        while not doAllClansHaveGames and iterations < 50:
+        while iterations < 50:
             team_game_data_copy = team_game_data.copy()
             for matchup in possible_matchups:
                 if round:
@@ -2702,7 +2701,7 @@ class RoundRobinTournament(Tournament):
             print("Teams in list: {}\nTeams created: {}".format(teams_list, games_created))
             # Check if enough games were found... Redo if not
             if len(teams_list) == len(games_created):
-                doAllClansHaveGames = True
+                break
             else:
                 # Not enough games were created... Redo the matchups
                 games_created.clear()


### PR DESCRIPTION
PR contains a patch to iterate match selection until all teams have been assigned games. If not all teams have been assigned games for the new round, the possible match-ups will be shuffled and recomputed. If no successful match-ups are found in 50 iterations, then no games will be created.