### PR TITLE
Prevent bye team from being added to game list for CL

### DIFF
--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -2448,6 +2448,9 @@ class RoundRobinTournament(Tournament):
     def uses_byes(self):
         return False
 
+    def use_all_teams_in_last_round(self):
+        return True
+
     def games_created_at_once(self):
         return 2
 
@@ -2537,8 +2540,10 @@ class RoundRobinTournament(Tournament):
                     # check to see if this is the last team that needs a bye. We include this team
                     # because there could be a chance that they do not get a game in the last two rounds due to
                     # the games they needed are for teams with byes
+
+                    #! Should not be needed... Prevents last round from being made due to there being a check in CL for all teams in list having games
                     teams_with_byes = TournamentTeam.objects.filter(round_robin_tournament=self, has_had_bye=True)
-                    if teams_with_byes.count() == len(shuffled_team_list_read_only):
+                    if self.use_all_teams_in_last_round() and teams_with_byes.count() == len(shuffled_team_list_read_only):
                         # all teams have byes now, so include them all to make sure all games get created
                         log_tournament("Last team to get a bye: {}, add it to the list and make sure all games are created".format(shuffled_team_list_read_only[i].id), self)
                         teams_list.append(shuffled_team_list_read_only[i].id)
@@ -4772,6 +4777,9 @@ class ClanLeagueTournament(RoundRobinTournament):
     def uses_byes(self):
         if self.number_teams % 2 != 0:
             return True
+        return False
+
+    def use_all_teams_in_last_round(self):
         return False
 
     def games_created_at_once(self):


### PR DESCRIPTION
Currently it is not possible for the last round of CL tournaments to be made. The code previously would add all teams to the list of games to make which would prevent matchups from being accepted. Newer audit code applies only to CL in that all teams in the list get matched up (to prevent cases of only a subset getting matches)

Change relies on the type of PR tournament to differentiate whether bye team should be added to list in final round.