### PR TITLE
Fix clan update functions for players

### DIFF
--- a/wlct/cogs/clot.py
+++ b/wlct/cogs/clot.py
@@ -131,6 +131,7 @@ class Clot(commands.Cog, name="clot"):
                           bb!admin rtl -p - shows current players on the RTL
                           bb!admin rtl -r <discord_id> - removes player from RTL using Discord ID
                           bb!admin cache <tournament_id> - forcibly runs the cache on a tournament
+                          bb!admin update_clan <clan_id> - forcibly update player clans in specified clan
                           bb!admin add <player_token> <tournament_id> - adds this player as an admin for the tournament
                           bb!admin create_game <tournament_id> <round_number> <game_data> - creates a game with the game data in the specified round number 
                           ''',
@@ -268,6 +269,18 @@ class Clot(commands.Cog, name="clot"):
                         await ctx.send("Successfully queued up {} to be re-cached".format(tournament.name))
                     else:
                         await ctx.send("Tournament {} does not exist.")
+                else:
+                    await ctx.send("Please enter a numeric id.")
+            elif cmd == "update_clan":
+                # set clan to queue for updating player clans
+                if option.isnumeric():
+                    # option is the clan id to run updating on
+                    clan = await self.bot.bridge.getClans(id=int(option))
+                    if clan:
+                        self.bot.players_clan_queue.append(clan[0].id)
+                        await ctx.send("Successfully queued up {} to have player clans updated".format(clan[0].name))
+                    else:
+                        await ctx.send("Clan {} does not exist.".format(option))
                 else:
                     await ctx.send("Please enter a numeric id.")
             elif cmd == "process":

--- a/wlct/cogs/clot.py
+++ b/wlct/cogs/clot.py
@@ -1,3 +1,5 @@
+import traceback
+
 import discord
 from discord.ext import commands
 
@@ -35,7 +37,7 @@ class Clot(commands.Cog, name="clot"):
             tplayer = await self.bot.bridge.getTournamentPlayers(player=player)
             for p in tplayer:
                 tpi += 1
-                games = await self.bot.bridge.getTournamentGameEntries(team=p.team)
+                games = await self.bot.bridge.getTournamentGameEntries(team=p.team_id)
                 gpi += len(games)
             win_pct = 0
             if wins + losses != 0:
@@ -146,7 +148,7 @@ class Clot(commands.Cog, name="clot"):
                     if arg:
                         game = await self.bot.bridge.getGames(gameid=arg)
                         if game:
-                            game_logs = ProcessGameLog.objects.filter(game=game[0]).order_by('-timestamp')[:2]
+                            game_logs = await self.bot.bridge.getProcessGameLogsLast2(game=game[0])
                             if game_logs:
                                 await self.send_log_message(ctx, "process game", game_logs)
                             else:
@@ -446,18 +448,18 @@ class Clot(commands.Cog, name="clot"):
                             # Adds clan filters to the channel
                             discord_channel_filter = await self.bot.bridge.getDiscordChannelClanFilters(link=cl, clan=clan)
                             if discord_channel_filter:
-                                await ctx.send("Filter for {} and {} already exists. Use ``bb!links`` to see all links and filters.".format(clan.name, cl.tournament.name))
+                                await ctx.send("Filter for {} and {} (id: {}) already exists. Use ``bb!links`` to see all links and filters.".format(clan.name, cl.tournament.name, cl.tournament.id))
                                 continue
                             new_filter = await self.bot.bridge.createDiscordChannelClanFilter(link=cl, clan=clan)
                         elif arg2 == "-p":
                             # Adds player filters to the channel
                             discord_channel_filter = await self.bot.bridge.getDiscordChannelPlayerFilters(link=cl, player=player)
                             if discord_channel_filter:
-                                await ctx.send("Filter for {} and {} already exists. Use ``bb!links`` to see all links and filters.".format(player.name, cl.tournament.name))
+                                await ctx.send("Filter for {} and {} (id: {}) already exists. Use ``bb!links`` to see all links and filters.".format(player.name, cl.tournament.name, cl.tournament.id))
                                 continue
                             new_filter = await self.bot.bridge.createDiscordChannelPlayerFilter(link=cl, player=player)
 
-                        new_filter.save()
+                        await self.bot.bridge.saveObject(new_filter)
                         total_filters_added += 1
 
                     await ctx.send("Successfully added {} filters to this channel.".format(total_filters_added))
@@ -469,10 +471,10 @@ class Clot(commands.Cog, name="clot"):
                         clan_filters = await self.bot.bridge.getDiscordChannelClanFilters(link__channelid=ctx.message.channel.id)
                         player_filters = await self.bot.bridge.getDiscordChannelPlayerFilters(link__channelid=ctx.message.channel.id)
                         for cf in clan_filters:
-                            cf.delete()
+                            await self.bot.bridge.deleteObject(cf)
                             total_filters_removed += 1
                         for pf in player_filters:
-                            pf.delete()
+                            await self.bot.bridge.deleteObject(pf)
                             total_filters_removed += 1
                     else:
                         for cl in discord_channel_link:
@@ -480,13 +482,13 @@ class Clot(commands.Cog, name="clot"):
                                 # Remove all filters applying to the channel, clan and (optionally) tournament
                                 discord_channel_filter = await self.bot.bridge.getDiscordChannelClanFilters(link=cl, clan=clan)
                                 if discord_channel_filter:
-                                    discord_channel_filter[0].delete()
+                                    await self.bot.bridge.deleteObject(discord_channel_filter[0])
                                     total_filters_removed += 1
                             elif arg2 == "-p":
                                 # Remove all filters applying to the channel, player and (optionally) tournament
                                 discord_channel_filter = await self.bot.bridge.getDiscordChannelPlayerFilters(link=cl, player=player)
                                 if discord_channel_filter:
-                                    discord_channel_filter[0].delete()
+                                    await self.bot.bridge.deleteObject(discord_channel_filter[0])
                                     total_filters_removed += 1
 
                     if total_filters_removed:
@@ -565,16 +567,16 @@ class Clot(commands.Cog, name="clot"):
                             player = player[0]
                             if hasattr(tournament, 'parent_tournament'):
                                 if tournament.parent_tournament:
-                                    print("Tournament Parent ID {}".format(tournament.parent_tournament.id))
-                                if player.id != tournament.created_by.id and (
-                                        tournament.parent_tournament and tournament.parent_tournament.id != 369):  # hard code this for clan league
+                                    print("Tournament Parent ID {}".format(tournament.parent_tournament_id))
+                                if player.id != tournament.created_by_id and (
+                                        tournament.parent_tournament and tournament.parent_tournament_id != 369):  # hard code this for clan league
                                     await ctx.send(
                                         "The creator of the tournament is the only one who can link private tournaments: {}".format(
                                             tournament.name))
                                     continue
                             else:
                                 # no parent tournament, must be creator
-                                if player.id != tournament.created_by.id:
+                                if player.id != tournament.created_by_id:
                                     await ctx.send(
                                         "The creator of the tournament is the only one who can link private tournaments: {}".format(
                                             tournament.name))
@@ -606,13 +608,13 @@ class Clot(commands.Cog, name="clot"):
                             clan_filters = await self.bot.bridge.getDiscordChannelClanFilters(link=discord_channel_link)
                             for cf in clan_filters:
                                 total_filters_removed += 1
-                                cf.delete()
+                                await self.bot.bridge.deleteObject(cf)
                             player_filters = await self.bot.bridge.getDiscordChannelPlayerFilters(link=discord_channel_link)
                             for pf in player_filters:
                                 total_filters_removed += 1
-                                pf.delete()
+                                await self.bot.bridge.deleteObject(pf)
 
-                            discord_channel_link.delete()
+                            await self.bot.bridge.deleteObject(discord_channel_link)
                             total_successfully_updated += 1
                         else:
                             await ctx.send(
@@ -677,13 +679,13 @@ class Clot(commands.Cog, name="clot"):
                             player = player[0]
                             if hasattr(tournament, 'parent_tournament'):
                                 if tournament.parent_tournament:
-                                    print("Tournament Parent ID {}".format(tournament.parent_tournament.id))
-                                if player.id != tournament.created_by.id and (tournament.id != 168) and (tournament.id != 109) and (tournament.id != 167) and (tournament.parent_tournament and tournament.parent_tournament.id != 369):  # hard code this for clan league
+                                    print("Tournament Parent ID {}".format(tournament.parent_tournament_id))
+                                if player.id != tournament.created_by_id and (tournament.id != 168) and (tournament.id != 109) and (tournament.id != 167) and (tournament.parent_tournament and tournament.parent_tournament_id != 369):  # hard code this for clan league
                                     await ctx.send("The creator of the tournament is the only one who can link private tournaments.")
                                     return
                             else:
                                 # no parent tournament, must be creator
-                                if player.id != tournament.created_by.id:
+                                if player.id != tournament.created_by_id:
                                     await ctx.send(
                                         "The creator of the tournament is the only one who can link private tournaments.")
                                     return
@@ -711,13 +713,13 @@ class Clot(commands.Cog, name="clot"):
                             clan_filters = await self.bot.bridge.getDiscordChannelClanFilters(link=discord_channel_link)
                             for cf in clan_filters:
                                 total_filters_removed += 1
-                                cf.delete()
+                                await self.bot.bridge.deleteObject(cf)
                             player_filters = await self.bot.bridge.getDiscordChannelPlayerFilters(link=discord_channel_link)
                             for pf in player_filters:
                                 total_filters_removed += 1
-                                pf.delete()
+                                await self.bot.bridge.deleteObject(pf)
 
-                            discord_channel_link.delete()
+                            await self.bot.bridge.deleteObject(discord_channel_link)
                             await ctx.send("You've removed the link from this channel and {} filters".format(total_filters_removed))
                         else:
                             await ctx.send("There is no existing link for tournament {} and this channel.".format(tournament.name))
@@ -767,7 +769,7 @@ class Clot(commands.Cog, name="clot"):
                     await ctx.send(message_data)
                     message_data = ""
 
-                message_data += "{} (ID: {}) | {} (ID: {})\n".format(cf.clan.name, cf.clan.id, cf.link.tournament.name, cf.link.tournament.id)
+                message_data += "{} (ID: {}) | {} (ID: {})\n".format(cf.clan.name, cf.clan.id, cl.tournament.name, cl.tournament.id)
 
             # List all player filters
             message_data += "\nPlayer Filters:\n"
@@ -776,7 +778,7 @@ class Clot(commands.Cog, name="clot"):
                     await ctx.send(message_data)
                     message_data = ""
 
-                message_data += "{} (Token: {}) | {} (ID: {})\n".format(pf.player.name, pf.player.token, pf.link.tournament.name, pf.link.tournament.id)
+                message_data += "{} (Token: {}) | {} (ID: {})\n".format(pf.player.name, pf.player.token, cl.tournament.name, cl.tournament.id)
 
             if message_data:
                 await ctx.send(message_data)
@@ -797,20 +799,20 @@ class Clot(commands.Cog, name="clot"):
                 if len(player):
                     player = player[0]
                     # make sure the discord id is not already here
-                    current_discord = await self.bot.bridge.getPlayers(discord_member__memberid=ctx.message.author.id)
-                    if len(current_discord):
-                        current_discord = current_discord[0]
-                        cd_name = self.bot.get_user(current_discord.discord_member.memberid)
+                    discord_member = await self.bot.bridge.getDiscordUsers(memberid=ctx.message.author.id)
+
+                    if len(discord_member) and player.discord_member_id != discord_member[0].id:
+                        cd_name = self.bot.get_user(ctx.message.author.id)
                         new_name = ctx.message.author.name
 
                         # do the unlinking
                         player.discord_member = None
-                        player.save()
+                        await self.bot.bridge.saveObject(player)
                         await ctx.send("Your discord ID is already associated with another account, unlinking {} and linking {}.".format(cd_name, new_name))
+                    elif len(discord_member):
+                        await ctx.send("Your account is already linked to the CLOT")
 
-                    if player.discord_member is not None and player.discord_member.memberid == ctx.message.author.id:
-                        await ctx.send("You're account is already linked on the CLOT.")
-                    elif player.discord_member is None:
+                    if not player.discord_member_id:
                         print("Saving discord id: {} for user".format(ctx.message.author.id))
                         discord_obj = await self.bot.bridge.getDiscordUsers(memberid=ctx.message.author.id)
                         if not len(discord_obj):
@@ -818,7 +820,7 @@ class Clot(commands.Cog, name="clot"):
                         else:
                             discord_obj = discord_obj[0]
                         player.discord_member = discord_obj
-                        player.save()
+                        await self.bot.bridge.saveObject(player)
                         await ctx.send("You've successfully linked your discord account to the CLOT.")
                 else:
                     await ctx.send(
@@ -838,16 +840,19 @@ class Clot(commands.Cog, name="clot"):
             await ctx.send("Gathering tournament data....")
             division_data = "Clan League Divisions\n"
 
-            cl = await self.bot.bridge.getClanLeagues(id=369)[0]
-            divisions = await self.bot.bridge.getClanLeagueDivisionsOrderByTitle(league=cl)
+            cl = await self.bot.bridge.getClanLeagues(id=369)
+            if len(cl):
+                divisions = await self.bot.bridge.getClanLeagueDivisionsOrderByTitle(league=cl[0])
 
-            for division in divisions:
-                if len(division_data) > 1500:
-                    await ctx.send(division_data)
-                    division_data = ""
-                division_data += "{} | Id: {}\n".format(division.title, division.id)
+                for division in divisions:
+                    if len(division_data) > 1500:
+                        await ctx.send(division_data)
+                        division_data = ""
+                    division_data += "{} | Id: {}\n".format(division.title, division.id)
 
-            await ctx.send(division_data)
+                await ctx.send(division_data)
+            else:
+                await ctx.send("There are no active CL divisions to link")
         except Exception as e:
             await self.bot.handle_command_exception(ctx, str(e))
 
@@ -874,7 +879,7 @@ class Clot(commands.Cog, name="clot"):
                 tournament_data += "Clan League Tournaments\n"
             elif option == "-s":
                 await ctx.send("Searching for Tournaments starting with {}...".format(arg))
-                tournaments = await self.bot.bridge.getTournaments(name__istartswith=arg.lower(), private=False)[:10]
+                tournaments = (await self.bot.bridge.getTournaments(name__istartswith=arg.lower(), private=False))[:10]
                 data = "Showing top 10 results\n"
                 for t in tournaments:
                     data += "{} (Id: {}) | <{}>\n".format(t.name, t.id, t.get_full_public_link())
@@ -902,12 +907,12 @@ class Clot(commands.Cog, name="clot"):
                         link_text += "tournaments/{}".format(child_tournament.id)
                     if option == "-f":  # only finished tournaments
                         if child_tournament.is_finished:
-                            tournament_data += "{} (Id: {}) | <{}> | Winner: {}\n".format(child_tournament.name, child_tournament.id, link_text,
-                                                                         await self.bot.bridge.get_team_data(child_tournament.winning_team))
+                            winning_team = await self.bot.bridge.get_team_data(child_tournament.winning_team_id)
+                            tournament_data += "{} (Id: {}) | <{}> | Winner: {}\n".format(child_tournament.name, child_tournament.id, link_text, winning_team)
                     elif option == "-o":  # only open tournaments
                         if not child_tournament.has_started and not child_tournament.private:
-                            tournament_data += "{} (Id: {}) | <{}> | {}\n".format(child_tournament.name, child_tournament.id, link_text,
-                                                                               child_tournament.spots_left)
+                            open_spots = await self.bot.bridge.get_tournament_open_seats(child_tournament)
+                            tournament_data += "{} (Id: {}) | <{}> | {}\n".format(child_tournament.name, child_tournament.id, link_text, open_spots)
                     elif option == "-p":  # only in progress
                         if child_tournament.has_started and not child_tournament.private:
                             tournament_data += "{} (Id: {}) | <{}>\n".format(child_tournament.name, child_tournament.id, link_text)
@@ -1011,16 +1016,15 @@ class Clot(commands.Cog, name="clot"):
     @commands.command(brief="Displays all clans on the CLOT")
     async def clans(self, ctx):
         try:
-            clans = await self.bot.bridge.getClansAllOrderById()
+            clans = await self.bot.bridge.getClansDictOrderByIdWithPlayerCount()
             await ctx.send("Gathering clans data....")
             clans_data = "Clans on the CLOT\n\n"
             for clan in clans:
-                player = await self.bot.bridge.getPlayers(clan=clan)
-                if len(player):
+                if clan['clan'] is not None and clan['player_count']:
                     if len(clans_data) > 1500:
                         await ctx.send(clans_data)
                         clans_data = ""
-                    clans_data += "{}: {}\n".format(clan.id, clan.name)
+                    clans_data += "{}: {}\n".format(clan['clan'], clan['clan__name'])
             await ctx.send(clans_data)
         except Exception as e:
             await self.bot.handle_command_exception(ctx, str(e))

--- a/wlct/cogs/clotbridge.py
+++ b/wlct/cogs/clotbridge.py
@@ -372,6 +372,10 @@ class CLOTBridge:
         tournament.cache_data()
 
     @database_sync_to_async
+    def update_player_clans(self, clan):
+        clan.update_player_clans()
+
+    @database_sync_to_async
     def get_team_data(self, team):
         return get_team_data(team)
 

--- a/wlct/cogs/clotbridge.py
+++ b/wlct/cogs/clotbridge.py
@@ -1,3 +1,5 @@
+from django.db.models import Count
+
 from wlct.models import Clan, Player, DiscordUser, DiscordChannelClanFilter, DiscordChannelPlayerFilter, DiscordChannelTournamentLink, TournamentAdministrator, DiscordTournamentUpdate
 from wlct.tournaments import Tournament, TournamentTeam, TournamentPlayer, MonthlyTemplateRotation, get_games_finished_for_team_since, find_tournaments_by_division_id, find_tournament_by_id, get_team_data_no_clan, RealTimeLadder, get_real_time_ladder, get_team_data, ClanLeague, ClanLeagueTournament, ClanLeagueDivision, TournamentGame, TournamentGameEntry, TournamentRound, get_team_data_no_clan_player_list
 from wlct.logging import ProcessGameLog, ProcessNewGamesLog, log_command_exception
@@ -47,6 +49,10 @@ class CLOTBridge:
         return list(Tournament.objects.all())
 
     @database_sync_to_async
+    def getTournamentFromChannelLink(self, link):
+        return DiscordChannelTournamentLink.objects.get(id=link).tournament
+
+    @database_sync_to_async
     def getTournamentPlayers(self, **kwargs):
         return list(TournamentPlayer.objects.filter(**kwargs).select_related('player'))
 
@@ -56,7 +62,7 @@ class CLOTBridge:
 
     @database_sync_to_async
     def getTournamentTeams(self, **kwargs):
-        return list(TournamentTeam.objects.filter(**kwargs).select_related('clan_league_clan__clan'))
+        return list(TournamentTeam.objects.filter(**kwargs).select_related('clan_league_clan__clan').select_related('tournament'))
 
     @database_sync_to_async
     def getTournamentTeamsOrderByRatingWins(self, **kwargs):
@@ -80,7 +86,7 @@ class CLOTBridge:
 
     @database_sync_to_async
     def getChannelTournamentLinks(self, **kwargs):
-        return list(DiscordChannelTournamentLink.objects.filter(**kwargs))
+        return list(DiscordChannelTournamentLink.objects.filter(**kwargs).select_related('tournament'))
 
     @database_sync_to_async
     def getChannelTournamentLinksAll(self):
@@ -108,11 +114,11 @@ class CLOTBridge:
 
     @database_sync_to_async
     def getDiscordChannelClanFilters(self, **kwargs):
-        return list(DiscordChannelClanFilter.objects.filter(**kwargs))
+        return list(DiscordChannelClanFilter.objects.filter(**kwargs).select_related('clan'))
 
     @database_sync_to_async
     def getDiscordChannelPlayerFilters(self, **kwargs):
-        return list(DiscordChannelPlayerFilter.objects.filter(**kwargs))
+        return list(DiscordChannelPlayerFilter.objects.filter(**kwargs).select_related('player'))
 
     @database_sync_to_async
     def getClanLeagueTournaments(self, **kwargs):
@@ -129,6 +135,12 @@ class CLOTBridge:
     @database_sync_to_async
     def getClansAllOrderById(self, **kwargs):
         return list(Clan.objects.filter(**kwargs).order_by('id'))
+
+    # Returns list of dicts in form {'clan': <id>, 'clan__name': '<name>', 'player_count': <numberOfPlayersInClan>}
+    # Also returns players not in clan... 'clan' and 'clan__name' will be None
+    @database_sync_to_async
+    def getClansDictOrderByIdWithPlayerCount(self, **kwargs):
+        return list(Player.objects.filter(**kwargs).select_related('clan').values('clan', 'clan__name').annotate(player_count=Count('clan')).order_by('clan_id'))
 
     @database_sync_to_async
     def getClansAll(self, **kwargs):
@@ -321,7 +333,7 @@ class CLOTBridge:
     '''
     @database_sync_to_async
     def createDiscordUser(self, **kwargs):
-        discord_user = DiscordUser(*kwargs)
+        discord_user = DiscordUser(**kwargs)
         discord_user.save()
         return discord_user
 
@@ -343,6 +355,10 @@ class CLOTBridge:
     @database_sync_to_async
     def getProcessGameLogs(self, **kwargs):
         return list(ProcessGameLog.objects.filter(**kwargs))
+
+    @database_sync_to_async
+    def getProcessGameLogsLast2(self, **kwargs):
+        return list(ProcessGameLog.objects.filter(**kwargs).order_by('-timestamp')[:2])
 
     @database_sync_to_async
     def getProcessNewGameLogs(self, **kwargs):
@@ -394,6 +410,10 @@ class CLOTBridge:
     @database_sync_to_async
     def does_game_pass_filter(self, cl, game):
         return cl.does_game_pass_filter(game)
+
+    @database_sync_to_async
+    def get_tournament_open_seats(self, tournament):
+        return tournament.spots_left
 
 '''
 Helper class to act as the ladder with a reference to the real ladder in order to make the DB operations async

--- a/wlct/cogs/tasks.py
+++ b/wlct/cogs/tasks.py
@@ -310,6 +310,13 @@ class Tasks(commands.Cog, name="tasks"):
                 await self.bot.bridge.cache_data(t)
                 self.bot.cache_queue.pop(i)
 
+    async def handle_players_clan_queue(self):
+        while len(self.bot.players_clan_queue):
+            clan = await self.bot.bridge.getClans(id=self.bot.players_clan_queue[0])
+            self.bot.debug_print("Updating player clans for players in {}".format(clan[0].name))
+            await self.bot.bridge.update_player_clans(clan[0])
+            self.bot.players_clan_queue.pop(0)
+
     async def handle_critical_errors(self):
         logs = await self.bot.bridge.getLogs(level=LogLevel.critical, bot_seen=False)
         for log in logs:
@@ -398,6 +405,10 @@ class Tasks(commands.Cog, name="tasks"):
         await self.handle_cache_queue()
         end = datetime.datetime.utcnow()
         self.bot.perf_counter("Cache queue took {} total seconds".format((end-start).total_seconds()))
+        start = datetime.datetime.utcnow()
+        await self.handle_players_clan_queue()
+        end = datetime.datetime.utcnow()
+        self.bot.perf_counter("Player Clan Update Queue took {} total seconds".format((end - start).total_seconds()))
         start = datetime.datetime.utcnow()
         await self.handle_process_queue()
         end = datetime.datetime.utcnow()

--- a/wlct/management/commands/bot.py
+++ b/wlct/management/commands/bot.py
@@ -38,6 +38,7 @@ class WZBot(commands.AutoShardedBot):
         self.game_log_channels = []
         self.last_task_run = timezone.now()
         self.cache_queue = []
+        self.players_clan_queue = []
         self.process_queue = []
         self.clot_server = None
         self.executions = 0


### PR DESCRIPTION
PR adds a fix for the scripts for scraping new clans/grabbing new clan imgs. Also added functions to update the clans a player is in (currently there are no checks to update the player's clan after initial login). There is also an admin command to specifically queue a specific clan for update.

! Currently the process to update the clan a player is in is run every hour (as part of the same worker thread to grab new clans)