### PR TITLE
Fix bot cmds and lax link conditions

### DIFF
--- a/wlct/cogs/tasks.py
+++ b/wlct/cogs/tasks.py
@@ -32,20 +32,23 @@ class Tasks(commands.Cog, name="tasks"):
                 data = ""
                 team1 = game.teams.split('.')[0]
                 team2 = game.teams.split('.')[1]
-                player1 = ladder.get_player_from_teamid(team1)
-                player2 = ladder.get_player_from_teamid(team2)
-                if player1.discord_member and player2.discord_member:
-                    data += "<@{}> vs. <@{}> [Game Link]({})\n".format(player1.discord_member.memberid, player2.discord_member.memberid,
-                                                                       game.game_link)
-                elif player1.discord_member:
-                    data += "<@{}> vs. <{}> [Game Link]({})\n".format(player1.discord_member.memberid, player2.name,
-                                                                       game.game_link)
-                elif player2.discord_member:
-                    data += "<{}> vs. <@{}> [Game Link]({})\n".format(player1.name, player2.discord_member.memberid,
-                                                                       game.game_link)
-                else:
-                    await self.bot.bridge.updateGameMentioned(game)
-                    return
+                player1 = await self.bot.bridge.getTournamentPlayers(team=int(team1))
+                player2 = await self.bot.bridge.getTournamentPlayers(team=int(team2))
+                if player1 and player2:
+                    player1 = player1[0].player
+                    player2 = player2[0].player
+                    if player1.discord_member and player2.discord_member:
+                        data += "<@{}> vs. <@{}> [Game Link]({})\n".format(player1.discord_member.memberid, player2.discord_member.memberid,
+                                                                           game.game_link)
+                    elif player1.discord_member:
+                        data += "<@{}> vs. <{}> [Game Link]({})\n".format(player1.discord_member.memberid, player2.name,
+                                                                           game.game_link)
+                    elif player2.discord_member:
+                        data += "<{}> vs. <@{}> [Game Link]({})\n".format(player1.name, player2.discord_member.memberid,
+                                                                           game.game_link)
+                    else:
+                        await self.bot.bridge.updateGameMentioned(game)
+                        return
                 emb.add_field(name="Game", value=data, inline=True)
                 if player1 and player1.discord_member:
                     user = self.bot.get_user(player1.discord_member.memberid)

--- a/wlct/tests/data.py
+++ b/wlct/tests/data.py
@@ -108,6 +108,10 @@ class TournamentDataHelper:
         if 'num_clans'in kwargs:
             self.num_clans = int(kwargs['num_clans'])
 
+        self.num_templates = 2
+        if 'num_templates' in kwargs:
+            self.num_templates = int(kwargs['num_templates'])
+
         self.created_clans = {}
         self.tournament_id = 0
 
@@ -153,7 +157,7 @@ class TournamentDataHelper:
 
                 # Create templates for cl division
                 unique_template_ids = []
-                for i in range(int(num_1v1s)):
+                for j in range(int(num_1v1s)):
                     template_id = generate_random_template()
                     while template_id in unique_template_ids:
                         template_id = generate_random_template()
@@ -161,7 +165,7 @@ class TournamentDataHelper:
 
                     ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=1, name="Template {} - 1v1".format(template_id))
 
-                for i in range(int(num_2v2s)):
+                for j in range(int(num_2v2s)):
                     template_id = generate_random_template()
                     while template_id in unique_template_ids:
                         template_id = generate_random_template()
@@ -169,13 +173,25 @@ class TournamentDataHelper:
 
                     ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=2, name="Template {} - 2v2".format(template_id))
 
-                for i in range(int(num_3v3s)):
+                for j in range(int(num_3v3s)):
                     template_id = generate_random_template()
                     while template_id in unique_template_ids:
                         template_id = generate_random_template()
                     unique_template_ids.append(template_id)
 
                     ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=3, name="Template {} - 3v3".format(template_id))
+            elif self.type == TournamentType.real_time_ladder:
+                rtl = RealTimeLadder.objects.create(name=name, created_by=creator, description=description)
+                self.tournament_id = rtl.id
+
+                # Generate templates for the RTL
+                unique_template_ids = []
+                for j in range(self.num_templates):
+                    template_id = generate_random_template()
+                    while template_id in unique_template_ids:
+                        template_id = generate_random_template()
+                    unique_template_ids.append(template_id)
+                    RealTimeLadderTemplate.objects.create(template=template_id, ladder=rtl, name="Template {}".format(template_id))
 
         # Return self to allow chaining
         return self

--- a/wlct/tests/test_tournaments.py
+++ b/wlct/tests/test_tournaments.py
@@ -1,6 +1,12 @@
+from unittest.mock import patch
+
 from django.test import TestCase
+
+from wlct.api import API_TEST, TestResponse
 from wlct.tests.data import PlayerDataHelper, TournamentDataHelper, get_current_day_str
-from wlct.tournaments import TournamentType, ClanLeague, ClanLeagueDivision, ClanLeagueTournament, ClanLeagueTemplate, TournamentGame
+from wlct.models import Player
+from wlct.tournaments import TournamentType, ClanLeague, ClanLeagueDivision, ClanLeagueTournament, ClanLeagueTemplate, \
+    TournamentGame, RealTimeLadder, TournamentTeam
 from django.test import Client, override_settings
 from wlct.management.commands import engine
 
@@ -69,3 +75,60 @@ class ClanLeagueTests(TestCase):
             game_count = TournamentGame.objects.filter(tournament=tournament, is_finished=True).count()
             self.assertTrue(game_count == 6)
             print("Total games: {}".format(game_count))
+
+class RealTimeLadderTests(TestCase):
+    def setUp(self):
+        self.pdata_helper = PlayerDataHelper(num_players=2).populate()
+        self.tdata_helper = TournamentDataHelper(type=TournamentType.real_time_ladder, num_templates=4).populate()
+
+    def api_validate_template_locked(self, token, templateid):
+        response = TestResponse()
+        response.response_dict['tokenIsValid'] = 'true'
+        template_key = "template{}".format(templateid)
+        response.response_dict[template_key] = {
+            "result": "CannotUseTemplate",
+            "reasonCode": "MultiAttackAndAttackByPercentageLocked"
+        }
+        return response
+
+    @override_settings(DEBUG=True)
+    @patch.object(API_TEST, 'api_validate_token_for_template', api_validate_template_locked)
+    def test_real_time_ladder_ineligible_player(self):
+        playerid = self.pdata_helper.created_players[0]
+        player = Player.objects.get(id=playerid)
+        self.assertIsNotNone(player)
+
+        rtl = RealTimeLadder.objects.get(id=self.tdata_helper.tournament_id)
+
+        # Triggers new TournamentTeam path
+        self.assertRaises(RealTimeLadder.LockedTemplatesException, rtl.join_leave_player, player, True, True)
+        # Triggers existing TournamentTeam path
+        self.assertRaises(RealTimeLadder.LockedTemplatesException, rtl.join_leave_player, player, True, True)
+
+        # No player should have joined
+        self.assertFalse(TournamentTeam.objects.filter(active=True, tournament=rtl).exists())
+
+    @override_settings(DEBUG=True)
+    def test_real_time_ladder_eligible_player(self):
+        rtl = RealTimeLadder.objects.get(id=self.tdata_helper.tournament_id)
+
+        # Have both players join (successfully)
+        for playerid in self.pdata_helper.created_players:
+            player = Player.objects.get(id=playerid)
+            self.assertEquals(rtl.join_leave_player(player, True, False), "Looks like you're new to the **{}**. Welcome, and best of luck!".format(rtl.name))
+
+        # 2 players should have joined
+        self.assertTrue(TournamentTeam.objects.filter(active=True, tournament=rtl).count() == 2)
+
+        # Create new game
+        rtl.process_new_games()
+        self.assertTrue(TournamentGame.objects.filter(tournament=rtl).exists())
+
+        for playerid in self.pdata_helper.created_players:
+            player = Player.objects.get(id=playerid)
+            # Test double leaving (successful on first attempt, unsuccessful on second
+            self.assertEquals(rtl.join_leave_player(player, False, False), "You've left the ladder. Come back again soon.")
+            self.assertEquals(rtl.join_leave_player(player, False, False), "You're currently not on the ladder.")
+
+        # 0 players should be remaining
+        self.assertFalse(TournamentTeam.objects.filter(active=True, tournament=rtl).exists())

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -5868,14 +5868,14 @@ class RealTimeLadder(Tournament):
                 templates_list_copy.remove(entry.game.templateid)
 
         log_tournament("Template list after prune: {}".format(templates_list_copy), self)
-        while True:
-            shuffle(templates_list_copy)
-            for tid in templates_list_copy:
-                log_tournament("Picked new template out of the list: {}".format(tid), self)
-                if self.is_template_allowed(tid, team1) and self.is_template_allowed(tid, team2):
-                    log_tournament("Picked FINAL template for game: {}".format(tid), self)
-                    return tid
-
+        shuffle(templates_list_copy)
+        for tid in templates_list_copy:
+            log_tournament("Picked new template out of the list: {}".format(tid), self)
+            if self.is_template_allowed(tid, team1) and self.is_template_allowed(tid, team2):
+                log_tournament("Picked FINAL template for game: {}".format(tid), self)
+                return tid
+        # If player is not eligible on any templates, return nothing
+        return None
 
     def process_new_games(self):
         # handles creating new ladder games between players
@@ -5930,7 +5930,7 @@ class RealTimeLadder(Tournament):
 
                             game_data = "{}.{}".format(team1.id, team2.id)
 
-                            if get_games_against_since_hours(team1, team2, self, 1) == 0:
+                            if get_games_against_since_hours(team1, team2, self, 1) == 0 and tid:
                                 extra_settings = self.get_game_extra_settings()
                                 game = self.create_game_with_template_and_data(round, game_data, tid, extra_settings)
                                 if game:

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -407,6 +407,7 @@ class TournamentType:
     mtc = "Monthly Template Circuit"
     round_robin = "Round Robin"
     clan_league = "Clan League"
+    real_time_ladder = "Real-Time Ladder"
 
 
 class Tournament(models.Model):
@@ -6054,11 +6055,13 @@ class RealTimeLadder(Tournament):
             elif not tplayer.team.active and not join:
                 return "You're currently not on the ladder."
         else:
-            team = TournamentTeam(tournament=self, players=self.players_per_team, active=True, max_games_at_once=1, joined_time=timezone.now(), leave_after_game=leave_after_game)
-            team.save()
+            team = TournamentTeam.objects.create(tournament=self, players=self.players_per_team, active=False, max_games_at_once=1, joined_time=timezone.now(), leave_after_game=leave_after_game)
             # Check if player can play on any templates
             if not self.can_play_any_template(player.token, team):
                 raise RealTimeLadder.LockedTemplatesException()
+
+            team.active = True
+            team.save()
             tplayer = TournamentPlayer(player=player, tournament=self, team=team)
             tplayer.save()
             self.number_players += 1


### PR DESCRIPTION
PR fixes some of the bot commands that are causing issues:
* admin log command not sending msg when only 1 log exists
* laxing restrictions on using `linkt` and `linkd` so either clot admins or discord server admins can add any tournaments (previously needed server admin & creator of league/tourney
* rtl msg when trying to get teams (needed to use async stuff)

Updated the `bb!divisions` to take in a command to search a specific CL instead of the official cl (if no param give, defaults to official cl)

Also shortened the help description of the admin cmd