### PR TITLE
Customizable CL Game Start Intervals

### DIFF
--- a/wlct/templates/clan_league.html
+++ b/wlct/templates/clan_league.html
@@ -167,7 +167,7 @@
                       </div>
                 </div>
                 <br/>
-                <div class="form-group row">
+                <div class="form-group row" style="padding-top: 25px;">
                     <div class="input-group">
                         <label class="col-form-label" for="players_per_team"><b>Players Per Team:&nbsp;</b></label>
                         <select name="players_per_team" id="players_per_team" style="padding:10px;">
@@ -176,7 +176,16 @@
                             <option value="3">3</option>
                         </select>
                     </div>
-                    <div class="input-group" style="padding-top:25px;">
+                    <div class="input-group" style="padding-top: 25px;">
+                        <label class="col-form-label" for="game_start_interval"><b>Game Start Interval:&nbsp;</b></label>
+                        <input name="game_start_interval" id="game_start_interval" style="padding:10px;">
+                        <p style="padding-top: 5px;">
+                            Game start interval must be a "/" delimited string containing integers in the range [1,30]. Ex: "15" means games are created every 15 days; "15/20" means game creation alternates every 15 days & 20 days.
+                            <br>
+                            <span style="padding-top: 3px">* Leave blank for default CL intervals.</span>
+                        </p>
+                    </div>
+                    <div class="input-group" style="padding-top:50px;">
                         <button type="button" class="btn btn-sm btn-success" id="create-cl-template">+ Add New Template</button>
                     </div>
                 </div>

--- a/wlct/tests/data.py
+++ b/wlct/tests/data.py
@@ -163,7 +163,7 @@ class TournamentDataHelper:
                         template_id = generate_random_template()
                     unique_template_ids.append(template_id)
 
-                    ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=1, name="Template {} - 1v1".format(template_id))
+                    ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=1, name="Template {} - 1v1".format(template_id), game_start_interval="10/15")
 
                 for j in range(int(num_2v2s)):
                     template_id = generate_random_template()
@@ -171,7 +171,7 @@ class TournamentDataHelper:
                         template_id = generate_random_template()
                     unique_template_ids.append(template_id)
 
-                    ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=2, name="Template {} - 2v2".format(template_id))
+                    ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=2, name="Template {} - 2v2".format(template_id), game_start_interval="15")
 
                 for j in range(int(num_3v3s)):
                     template_id = generate_random_template()
@@ -179,7 +179,7 @@ class TournamentDataHelper:
                         template_id = generate_random_template()
                     unique_template_ids.append(template_id)
 
-                    ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=3, name="Template {} - 3v3".format(template_id))
+                    ClanLeagueTemplate.objects.create(templateid=int(template_id), league=cl, players_per_team=3, name="Template {} - 3v3".format(template_id), game_start_interval="15/20")
             elif self.type == TournamentType.real_time_ladder:
                 rtl = RealTimeLadder.objects.create(name=name, created_by=creator, description=description)
                 self.tournament_id = rtl.id
@@ -219,3 +219,7 @@ class TournamentDataHelper:
                         tplayers[i].player = Player.objects.get(id=self.created_clans[team.clan_league_clan.clan.id][player_idx+i])
                         tplayers[i].save()
                 player_idx += tournament.players_per_team
+
+class MockedRequest:
+    def __init__(self, **kwargs):
+        self.POST = kwargs['data']

--- a/wlct/tests/test_tournaments.py
+++ b/wlct/tests/test_tournaments.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from wlct.api import API_TEST, TestResponse
-from wlct.tests.data import PlayerDataHelper, TournamentDataHelper, get_current_day_str
+from wlct.tests.data import PlayerDataHelper, TournamentDataHelper, get_current_day_str, MockedRequest
 from wlct.models import Player
 from wlct.tournaments import TournamentType, ClanLeague, ClanLeagueDivision, ClanLeagueTournament, ClanLeagueTemplate, \
     TournamentGame, RealTimeLadder, TournamentTeam
@@ -75,6 +75,88 @@ class ClanLeagueTests(TestCase):
             game_count = TournamentGame.objects.filter(tournament=tournament, is_finished=True).count()
             self.assertTrue(game_count == 6)
             print("Total games: {}".format(game_count))
+
+    @override_settings(DEBUG=True)
+    def test_cl_valid_game_start_intervals(self):
+        # Verify that created templates all have correct game_start_interval values
+        cl = ClanLeague.objects.get(id=self.tdata_helper.tournament_id)
+
+        expectedOutput = {
+            1: "10/15",
+            2: "15",
+            3: "15/20"
+        }
+
+        # Add templates using default CL game intervals
+        sample_default_1v1_request = MockedRequest(data={'tournamentid': '71', 'templateid': '111121', 'players_per_team': '1', 'optype': 'add', 'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}', 'templatename': 'test no fill 1v1', 'game_start_interval': ''})
+        sample_default_2v2_request = MockedRequest(data={'tournamentid': '71', 'templateid': '111122', 'players_per_team': '2', 'optype': 'add', 'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}', 'templatename': 'test no fill 1v1', 'game_start_interval': ''})
+        sample_default_3v3_request = MockedRequest(data={'tournamentid': '71', 'templateid': '111123', 'players_per_team': '3', 'optype': 'add', 'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}', 'templatename': 'test no fill 1v1', 'game_start_interval': ''})
+        cl.add_template(sample_default_1v1_request)
+        cl.add_template(sample_default_2v2_request)
+        cl.add_template(sample_default_3v3_request)
+
+        # Test default game intervals
+        default_templates = ClanLeagueTemplate.objects.filter(league=cl)
+        for template in default_templates:
+            print("TEMPLATE: {} vs players {}".format(template.game_start_interval, template.players_per_team))
+            self.assertEquals(template.game_start_interval, expectedOutput[template.players_per_team])
+
+        # Test custom game intervals with valid input
+        custom_intervals = {'111111': "15", '222222': "15/20"}
+        sample_single_interval_request = MockedRequest(data={'tournamentid': '71', 'templateid': '111111', 'players_per_team': '1', 'optype': 'add', 'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}', 'templatename': 'test no fill 1v1', 'game_start_interval': '15'})
+        sample_multi_interval_request = MockedRequest(data={'tournamentid': '71', 'templateid': '222222', 'players_per_team': '1', 'optype': 'add', 'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}', 'templatename': 'test no fill 1v1', 'game_start_interval': '15/20'})
+        cl.add_template(sample_single_interval_request)
+        cl.add_template(sample_multi_interval_request)
+
+        custom_valid_templates = ClanLeagueTemplate.objects.filter(league=cl)
+        for template in custom_valid_templates.difference(default_templates):
+            self.assertEquals(template.game_start_interval, custom_intervals[template.players_per_team])
+
+    @override_settings(DEBUG=True)
+    def test_cl_invalid_game_start_intervals(self):
+        cl = ClanLeague.objects.get(id=self.tdata_helper.tournament_id)
+        
+
+        # Test invalid game intervals with non-integer
+        sample_invalid_interval_request = MockedRequest(
+            data={'tournamentid': '71', 'templateid': '111131', 'players_per_team': '1',
+                  'optype': 'add',
+                  'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}',
+                  'templatename': 'test no fill 1v1', 'game_start_interval': 'invalid'})
+        self.assertRaises(Exception, cl.add_template, sample_invalid_interval_request)
+
+        # Test invalid game intervals with negative input
+        sample_invalid_interval_request = MockedRequest(
+            data={'tournamentid': '71', 'templateid': '111132', 'players_per_team': '1',
+                  'optype': 'add',
+                  'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}',
+                  'templatename': 'test no fill 1v1', 'game_start_interval': '15/-1'})
+        self.assertRaises(Exception, cl.add_template, sample_invalid_interval_request)
+
+        # Test invalid game intervals with real number
+        sample_invalid_interval_request = MockedRequest(
+            data={'tournamentid': '71', 'templateid': '111133', 'players_per_team': '1',
+                  'optype': 'add',
+                  'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}',
+                  'templatename': 'test no fill 1v1', 'game_start_interval': '15/1.5'})
+        self.assertRaises(Exception, cl.add_template, sample_invalid_interval_request)
+
+        # Test invalid game intervals with too small input
+        sample_invalid_interval_request = MockedRequest(
+            data={'tournamentid': '71', 'templateid': '1111344', 'players_per_team': '1',
+                  'optype': 'add',
+                  'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}',
+                  'templatename': 'test no fill 1v1', 'game_start_interval': '15/0'})
+        self.assertRaises(Exception, cl.add_template, sample_invalid_interval_request)
+
+        # Test invalid game intervals with too large input
+        sample_invalid_interval_request = MockedRequest(
+            data={'tournamentid': '71', 'templateid': '111135', 'players_per_team': '1',
+                  'optype': 'add',
+                  'templatesettings': '{"PersonalMessage":"","Pace":"MultiDay"}',
+                  'templatename': 'test no fill 1v1', 'game_start_interval': '15/35'})
+        self.assertRaises(Exception, cl.add_template, sample_invalid_interval_request)
+
 
 class RealTimeLadderTests(TestCase):
     def setUp(self):

--- a/wltourney/static/js/tournament.js
+++ b/wltourney/static/js/tournament.js
@@ -201,7 +201,8 @@ function update_cl_templates(type, obj)
         var templateid = $("#templateid").val();
         var templatesettings = $("#templatesettings").val();
         var templatename = $("#templatename").val();
-        data = {"tournamentid" : tournamentid, "templateid": templateid, "players_per_team": players_per_team, "optype": type, "templatesettings" : templatesettings, "templatename" : templatename};
+        var game_start_interval = $("#game_start_interval").val();
+        data = {"tournamentid" : tournamentid, "templateid": templateid, "players_per_team": players_per_team, "optype": type, "templatesettings" : templatesettings, "templatename" : templatename, "game_start_interval": game_start_interval};
     }
     else if (type == "remove")
     {
@@ -220,6 +221,7 @@ function update_cl_templates(type, obj)
                 $("#templateid").val('');
                 $("#templatesettings").val('');
                 $("#templatename").val('');
+                $("#game_start_interval").val('');
                 hook_clan_league_buttons();
                 hook_pr_buttons();
             }


### PR DESCRIPTION
PR adds functionality to CL-type leagues to customize game intervals for templates

* Creator can choose interval for templates by specifying single integer or '/' delimited string containing integers
* Integers must be in range [1, 30]

PR also adds test for verifying that default & custom intervals are applied correctly