### PR TITLE
PR League Rendering Fix

### DIFF
--- a/wlct/management/commands/engine.py
+++ b/wlct/management/commands/engine.py
@@ -394,7 +394,7 @@ class Command(BaseCommand):
                 else:
                     engine = engine[0]
                     engine.last_run_time = timezone.now()
-                    engine.next_run_time = timezone.now() + datetime.timedelta(seconds=get_run_time())
+                    engine.next_run_time = timezone.now() + datetime.timedelta(seconds=get_run_time()*10)
                     engine.save()
 
                 print("Process Games Starting...")
@@ -409,7 +409,7 @@ class Command(BaseCommand):
                 log_exception()
             finally:
                 finished_time = timezone.now()
-                next_run = timezone.now() + datetime.timedelta(seconds=get_run_time())
+                next_run = timezone.now() + datetime.timedelta(seconds=get_run_time()*10)
                 total_run_time = (finished_time - engine.last_run_time).total_seconds()
                 log("Engine done running at {}, ran for a total of {} seconds. Next run at {}".format(finished_time, total_run_time, next_run),
                     LogLevel.engine)

--- a/wlct/views.py
+++ b/wlct/views.py
@@ -302,7 +302,7 @@ def league_display_view(request, id):
                 context.update({'pause_resume_buttons': league.get_pause_resume(player)})
                 context.update({'tournament': league})
                 return render(request, 'clan_league.html', context)
-            elif league.type == "Promotion/Relegation League":
+            elif league.type == "Promotional/Relegation League":
                 context.update({'pause_resume_buttons' : league.get_pause_resume(player)})
                 context.update({'tournament': league})
                 return render(request, 'pr.html', context)


### PR DESCRIPTION
PR fixes the PR league format to properly render in addition to showing the correct execution times for the MD tournament engine thread.

Prior, PR parent league tournament page would not render due to the wrong HTML template being loaded. This applied to current PR leagues and newly created tournaments (underlying backend functionality was not affected).