### PR TITLE
Revamp logs and improve back-end searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ This web application is written in the Django framework and the server side piec
 To setup a local test site you will need to do the following. 
 
 Install Python 3.7 - https://www.python.org/downloads/windows/  
-Install virtualenv - pip install virtualenv (you might need to open a new command windows after installing python, windows only)  
+Install virtualenv - `pip install virtualenv` (you might need to open a new command windows after installing python, windows only)  
 Install postgreSQL 11.6-3 - https://www.enterprisedb.com/downloads/postgres-postgresql-downloads  
 
 In the project folder run:  
 pip install -r requirements.txt  
 
-Create settings_local.py in the wltourney folder with the following:  
+Create `settings_local.py` in the `wltourney/` folder with the following:  
 
+```
 DEBUG=True  
 TEMPLATE_DEBUG=True
 DEBUG_ISSUES=False
@@ -27,28 +28,32 @@ DATABASES = {
         'ENGINE': 'django_postgrespool',  
         'NAME': 'your_database_name',  
         'USER': 'database_username',  
-        'PASSWORD': 'database_password',  
+        'PASSWORD': 'database_password',
         'HOST': 'localhost',  
         'PORT': '5432',  
     }  
 }  
+```
 
-You must create .env file in the project root...and set the following variables  
+You must create `.env` file in the project root...and set the following variables  
 
+```
 WZ_ENDPOINT=http://127.0.0.1:8000  
 WZ_ACCOUNT_EMAIL=WZEmailAddress  
 WZ_API_TOKEN=WZAPIToken - can be retrieved from https://www.warzone.com/wiki/Get_API_Token_API  
 WZ_ACCOUNT_TOKEN=AccountToken - visit public profile e.g. https://www.warzone.com/Profile?p=2719017226 and use the p value 2719017226  
-WZ_TEST_BOT_TOKEN=  
+WZ_TEST_BOT_TOKEN=<discord-bot-token>
+SECRET_KEY='<anything>'
+```
 
 Migrate database to the latest schema  
-python manage.py migrate
+`python manage.py migrate`
 
 Create a super user account for your local django database to be able to view the admin site (127.0.0.1:8000/admin)
-python manage.py createsuperuser
+`python manage.py createsuperuser`
 
 Run the testserver locally  
-python manage.py runserver --noreload
+`python manage.py runserver --noreload`
 
 # Logging into the Local CLOT Server
 The local server you're running will actually hit the warzone endpoint to log you in, however you need to set up the login redirect
@@ -64,18 +69,18 @@ The framework being used is Django. Please read-up and use this documentation fo
 # Bot  
 The Warzone bot is able to run in any server and was created to integrate with the CLOT directly. There is a real-time ladder, clan-league updates, and general rankings and statistics from the CLOT and main Warzone sites as well. 
 
-Please see bot.py  
+Please see `bot.py`  
 
 # Engine  
 Running in a separate process on the server, the engine runs every 180 seconds and processes ALL tournaments/leagues that are not finished  
 
-Please see engine.py 
+Please see `engine.py` 
 
 
 # Want the Discord Bot in your Server? 
 If you want the discord bot in your server please contact -B#0292. If the bot is already in your server you can create special channels that the bot will use to communicate updates to accordingly.  
 
-Create a channel named any of the following:  
+Create a channel named any of the following:
 real-time-ladder  
 real_time_ladder  
 monthly-template-circuit  

--- a/wlct/admin.py
+++ b/wlct/admin.py
@@ -11,18 +11,19 @@ class LogFilter(SimpleListFilter):
       # This is where you create filter options; we have two:
       # also loop through all tournaments and display those IDs here
         return [
-            ('informational', 'Informational'),
-            ('critical', 'Critical'),
-            ('error', 'Errors'),
-            ('warning', 'Warning'),
-            ('tournament', 'Tournament'),
-            ('tournament_game', 'Tournament Game'),
-            ('tournament_game_status', 'Tournament Game Status'),
-            ('engine', 'Engine'),
+            ('api', 'API'),
             ('bot', 'Bot'),
             ('clean_logs', 'Log Cleanup'),
             ('clotbook', 'CLOTBook'),
-            ('api', 'API'),
+            ('critical', 'Critical'),
+            ('engine', 'Engine'),
+            ('error', 'Errors'),
+            ('informational', 'Informational'),
+            ('schedule', 'Scheduling'),
+            ('tournament', 'Tournament'),
+            ('tournament_game', 'Tournament Game'),
+            ('tournament_game_status', 'Tournament Game Status'),
+            ('warning', 'Warning'),
             ('webhook', 'Webhook')
         ]
 
@@ -52,6 +53,8 @@ class LogFilter(SimpleListFilter):
             return queryset.distinct().filter(level=LogLevel.api)
         if self.value() == 'webhook':
             return queryset.distinct().filter(level=LogLevel.webhook)
+        if self.value() == 'schedule':
+            return queryset.distinct().filter(level=LogLevel.schedule)
 
 class LogAdmin(admin.ModelAdmin):
     list_filter = (LogFilter, )
@@ -167,7 +170,7 @@ admin.site.register(TournamentGameEntry, TournamentGameEntryAdmin)
 
 
 class TournamentGameAdmin(admin.ModelAdmin):
-    search_fields = ['gameid', 'id']
+    search_fields = ['gameid', 'id', 'tournament__name', 'tournament__id', "teams"]
     raw_id_fields = ['winning_team', 'tournament']
 
 admin.site.register(TournamentGame, TournamentGameAdmin)

--- a/wlct/clotbook.py
+++ b/wlct/clotbook.py
@@ -194,13 +194,10 @@ class CLOTBook(models.Model):
             decimal1 = self.prob_to_decimal_odds(probs1)
             decimal2 = self.prob_to_decimal_odds(probs2)
 
-            log_cb_msg("Decimal odds for gameid {}: {} {}".format(game.gameid, decimal1, decimal2))
-
             american1 = self.decimal_odds_to_american(decimal1)
             american2 = self.decimal_odds_to_american(decimal2)
 
             # round the american to the nearest 5 or 0, and change that back into decimal
-            log_cb_msg("American odds for gameid {} before rounding: {} {}".format(game.gameid, american1, american2))
             american1 = self.round_to_nearest_multiple(american1)
             american2 = self.round_to_nearest_multiple(american2)
             american_odds = "{}!{}".format(american1, american2)
@@ -223,7 +220,6 @@ class CLOTBook(models.Model):
             team_odds2 = BetTeamOdds(bet_game=bet_game, players_index=1, decimal_odds=decimal2, american_odds=american2, players=players2)
             team_odds2.save()
 
-            log_cb_msg("Created initial odds for gameid {}".format(game.gameid))
         except:
             log_exception()
 

--- a/wlct/forms.py
+++ b/wlct/forms.py
@@ -1,5 +1,5 @@
 from django.forms import ModelForm
-from wlct.tournaments import SwissTournament, Tournament, TournamentTeam, SeededTournament, GroupStageTournament, GroupStageTournamentGroup, MonthlyTemplateRotation, PromotionalRelegationLeague, ClanLeague, RoundRobinTournament, RoundRobinRandomTeams
+from wlct.tournaments import SwissTournament, TournamentTeam, TournamentType, SeededTournament, GroupStageTournament, MonthlyTemplateRotation, PromotionalRelegationLeague, ClanLeague, RoundRobinRandomTeams
 from wlct.form_message_handling import FormError
 from wlct.validators import get_int, get_dropdown_to_boolean
 import math
@@ -137,7 +137,7 @@ class SeededTournamentForm(TournamentForm):
 class SwissTournamentForm(TournamentForm):
 
     def __init__(self, formdata):
-        self.tournament_type = "Swiss"
+        self.tournament_type = TournamentType.swiss
         self.extra_rounds = int(formdata['extra_rounds'])
         print("Found extra rounds for swiss tournamnent: {}".format(self.extra_rounds))
         super(SwissTournamentForm, self).__init__(formdata, SwissTournament.min_teams)
@@ -229,7 +229,7 @@ class LeagueForm:
 
 class MonthlyTemplateCircuitForm(LeagueForm):
     def __init__(self, formdata):
-        self.tournament_type = "Monthly Template Circuit"
+        self.tournament_type = TournamentType.mtc
         print("Creating Monthly Template Circuit: {}".format(formdata))
         super(MonthlyTemplateCircuitForm, self).__init__(formdata)
 
@@ -255,7 +255,7 @@ class MonthlyTemplateCircuitForm(LeagueForm):
 
 class PromotionRelegationLeagueForm(LeagueForm):
     def __init__(self, formdata):
-        self.tournament_type = "Promotion/Relegation League"
+        self.tournament_type = TournamentType.mtc
         formdata_copy = formdata.copy()
         print("Creating Promotional Relegation League: {}".format(formdata_copy))
         formdata_copy.update({'templateid': 0})  # fill this in as there is no template for P/R league until a season is created
@@ -272,7 +272,7 @@ class PromotionRelegationLeagueForm(LeagueForm):
 
 class ClanLeagueForm(LeagueForm):
     def __init__(self, formdata):
-        self.tournament_type = "Clan League"
+        self.tournament_type = TournamentType.clan_league
         print("Creating Clan League: {}".format(formdata))
         super(ClanLeagueForm, self).__init__(formdata)
 

--- a/wlct/logging.py
+++ b/wlct/logging.py
@@ -1,9 +1,7 @@
 from django.db import models
-from django.contrib import admin
 import datetime
 import traceback
 from django.conf import settings
-from enum import Enum
 import pytz
 from django.utils import timezone
 
@@ -18,6 +16,7 @@ class LogLevel:
     game = "TournamentGame"
     game_status = "TournamentGameStatus"
     engine = "Engine"
+    schedule = "Schedule"
     bot = "Bot"
     clean_logs = "Log Cleanup"
     process_game = "Process Game"
@@ -77,6 +76,7 @@ def log_bot_msg(msg):
         print("{} log: {}".format(logger.level, msg))
     logger.save()
 
+
 class Logger(models.Model):
 
     msg = models.TextField()
@@ -90,14 +90,19 @@ class Logger(models.Model):
     def __str__(self):
         return "[Time: {} Level: {}]: {}".format(self.timestamp, self.level, self.msg)
 
+
 class ProcessGameLog(Logger):
     game = models.ForeignKey('TournamentGame', on_delete=models.CASCADE)
 
     def __str__(self):
         return "[Time: {} Level: {}]: GameID: {}".format(self.timestamp, self.level, self.game.gameid)
 
+
 class ProcessNewGamesLog(Logger):
     tournament = models.ForeignKey('Tournament', on_delete=models.CASCADE)
+
+    def __str__(self):
+        return "[{}] Tournament {}-{}: {}".format(self.timestamp, self.tournament.id, self.tournament.name, self.msg)
 
 
 class TournamentLog(Logger):

--- a/wlct/management/commands/engine.py
+++ b/wlct/management/commands/engine.py
@@ -1,23 +1,18 @@
 # the main engine for the scheduler
-import threading
 import datetime
-from wlct.logging import log, LogLevel, log_exception, Logger, TournamentLog, TournamentGameLog, TournamentGameStatusLog, ProcessGameLog, ProcessNewGamesLog, BotLog, LogManager
+from wlct.logging import log, LogLevel, log_exception, LogManager
 from bs4 import BeautifulSoup
 from urllib.request import urlopen
 from wlct.models import Clan, Engine, Player, update_player_clans
-from wlct.tournaments import ClanLeague, ClanLeagueTournament, find_tournament_by_id, Tournament, TournamentGame, TournamentPlayer, TournamentTeam, TournamentGameEntry, TournamentRound, get_multi_day_ladder
-from django.conf import settings
+from wlct.tournaments import find_tournament_by_id, Tournament, TournamentGame, TournamentPlayer, TournamentTeam, TournamentGameEntry, TournamentRound, get_multi_day_ladder
 import pytz
-import threading
-from apscheduler.schedulers.background import BlockingScheduler, BackgroundScheduler
-from apscheduler.jobstores.base import ConflictingIdError
-from django_apscheduler.jobstores import DjangoJobStore
 from django.core.management.base import BaseCommand
 import gc
 from django.utils import timezone
 import urllib.request
 import os
-import sys, threading, json, time, traceback
+import sys, threading, json, time
+
 
 def get_run_time():
     return 180
@@ -283,14 +278,11 @@ class Command(BaseCommand):
                     child_tournament.cache_data()
                 except Exception as e:
                     log_exception()
-                finally:
-                    log("[CACHE]: Child tournament {} update done.".format(tournament.name), LogLevel.engine)
 
                 # if the tournament is finished and there are no more outstanding games that are in progress
                 # the cache is no longer dirty and we should stop looking at it
                 log("[CACHE]: {} has {} games in progress, is_finished: {}".format(child_tournament.name, games_in_progress, child_tournament.is_finished), LogLevel.engine)
                 if child_tournament.is_finished and games_in_progress == 0:
-                    log("[CACHE]: Child tournament {} cache is no longer dirty.".format(tournament.name), LogLevel.engine)
                     child_tournament.is_cache_dirty = False
                     child_tournament.save()
                 elif games_in_progress > 0:
@@ -315,7 +307,8 @@ class Command(BaseCommand):
                 try:
                     games = TournamentGame.objects.filter(is_finished=False, tournament=tournament)
                     games_in_progress = games.count()
-                    log("[PROCESS GAMES]: Processing {} games for tournament {}".format(games.count(), tournament.name), LogLevel.engine)
+                    if games_in_progress:
+                        log("[PROCESS GAMES]: Processing {} games for tournament {}".format(games.count(), tournament.name), LogLevel.engine)
                     for game in games.iterator():
                         # process the game
                         # query the game status
@@ -378,13 +371,13 @@ class Command(BaseCommand):
                 total_run_time = (finished_time - now_run_time).total_seconds()
                 log("RT Engine done running at {}, ran for a total of {} seconds. Next run at {}".format(finished_time,
                                                                                                       total_run_time, next_run),
-                    LogLevel.engine)
+                    LogLevel.schedule)
                 print("RT Engine done running at {}, ran for a total of {} seconds. Next run at {}".format(finished_time, total_run_time, next_run))
 
     def tournament_engine(self):
         while not self.shutdown:
             print("[WAIT - TOURNAMENT ENGINE]")
-            self.shutdown_event.wait(timeout=get_run_time()*10)
+            self.shutdown_event.wait(timeout=get_run_time())
             try:
                 engine = Engine.objects.all()
                 if not engine or engine.count() == 0:
@@ -412,7 +405,7 @@ class Command(BaseCommand):
                 next_run = timezone.now() + datetime.timedelta(seconds=get_run_time())
                 total_run_time = (finished_time - engine.last_run_time).total_seconds()
                 log("Engine done running at {}, ran for a total of {} seconds. Next run at {}".format(finished_time, total_run_time, next_run),
-                    LogLevel.engine)
+                    LogLevel.schedule)
                 print("Engine done running at {}, ran for a total of {} seconds. Next run at {}".format(finished_time,
                                                                                                       total_run_time, next_run))
                 engine.last_run_time = finished_time

--- a/wlct/models.py
+++ b/wlct/models.py
@@ -97,7 +97,7 @@ class Clan(models.Model):
         update_player_clans(players)
 
 class ClanAdmin(admin.ModelAdmin):
-    pass
+    search_fields = ['name']
 
 
 admin.site.register(Clan, ClanAdmin)

--- a/wltourney/settings.py
+++ b/wltourney/settings.py
@@ -18,6 +18,8 @@ from dotenv import load_dotenv
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 
+dotenv_path = join(BASE_DIR, '.env')
+load_dotenv(dotenv_path)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
@@ -174,9 +176,6 @@ LOGGING = {
         },
     }
 }
-
-dotenv_path = join(BASE_DIR, '.env')
-load_dotenv(dotenv_path)
 
 # load local settings if there are any
 # you must have a settings_local.py file next to settings.py for this to not pass on ImportError


### PR DESCRIPTION
PR drastically changes the logs stored to reduce the payload and cardinality. Also updates the readme.

Brief outline of changes:
- Adds new `schedule` log level for RT/MD engine thread execution timings
- Reduces `process_game` log sizes by omitting expected logs (ex. `Found player in team`)
- Removes a lot of unnecessary logs for `process_new_games` and `clotbetlogs`
- Improve searching and __str__ fields for multiple models
- Use TournamentType enum instead of manually typing string

**TODO**
- Need to determine which logs are worth keeping past 3 days
- Investigate which models are taking up the most space
- Investigate additional indices that should be used (and if this is worth the storage cost)