### PR TITLE
Add timeouts to external mtl/wz requests

### DIFF
--- a/wlct/cogs/common.py
+++ b/wlct/cogs/common.py
@@ -157,7 +157,7 @@ class Common(commands.Cog, name="general"):
             """displays the top 10 on Deadman's MDL"""
             mdl_url = "http://md-ladder.cloudapp.net/api/v1.0/players/?topk=10"
 
-            content = urllib.request.urlopen(mdl_url).read()
+            content = urllib.request.urlopen(mdl_url, timeout=120).read()
 
             data = json.loads(content)
             mdl_data = "Deadman's Multi-Day Ladder Top 10"
@@ -184,7 +184,7 @@ class Common(commands.Cog, name="general"):
             ladder_pageurls = ['https://www.warzone.com/LadderSeason?ID=0', 'http://www.warzone.com/LadderSeason?ID=1',
                                'https://www.warzone.com/LadderSeason?ID=4']
             for ladder_pageurl in ladder_pageurls:
-                ladder_page = urllib.request.urlopen(ladder_pageurl)
+                ladder_page = urllib.request.urlopen(ladder_pageurl, timeout=120)
                 soup = BeautifulSoup(ladder_page, 'html.parser')
                 tables = soup.find_all('table')
 

--- a/wlct/management/commands/engine.py
+++ b/wlct/management/commands/engine.py
@@ -114,7 +114,7 @@ class Command(BaseCommand):
         mdl_url = "https://warlight-mtl.com/api/v1.0/games/?topk=10"
 
         try:
-            content = urllib.request.urlopen(mdl_url).read()
+            content = urllib.request.urlopen(mdl_url, timeout=120).read()
         except Exception as e:
             log(traceback.format_exc(), LogLevel.critical)
             return

--- a/wlct/tournaments.py
+++ b/wlct/tournaments.py
@@ -6292,7 +6292,7 @@ class MultiDayLadder(Tournament):
         try:
             mdl_url = "http://md-ladder.cloudapp.net/api/v1.0/players/"
 
-            content = urllib.request.urlopen(mdl_url).read()
+            content = urllib.request.urlopen(mdl_url, timeout=120).read()
 
             data = json.loads(content)
             num_players = 0


### PR DESCRIPTION
Adds a 2 minute timeout to the `urllib.request.urlopen()` requests. Without a timeout specified, the fetches default to continuously blocking. I suspect this is behind the clot process freezing when the VM for the MTL also freezes or dies.

Unable to verify this is the actual root cause, but doesn't hurt to add these anyways.